### PR TITLE
Delete 'contributor' role entirely

### DIFF
--- a/app/policies/application_policy.rb
+++ b/app/policies/application_policy.rb
@@ -28,7 +28,7 @@ class ApplicationPolicy
   class Scope
     attr_reader :user, :scope
     def resolve
-      scope.all if @user.role?("admin") || @user.role?("manager") || @user.role?("contributor")
+      scope.all if @user.role?("admin") || @user.role?("manager")
     end
 
     def initialize(user, scope)

--- a/app/policies/category_policy.rb
+++ b/app/policies/category_policy.rb
@@ -7,7 +7,7 @@ class CategoryPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      return scope.all if @user.role?("admin") || @user.role?("manager") || @user.role?("contributor")
+      return scope.all if @user.role?("admin") || @user.role?("manager")
       scope.where(draft: false)
     end
   end

--- a/app/policies/due_date_policy.rb
+++ b/app/policies/due_date_policy.rb
@@ -10,7 +10,7 @@ class DueDatePolicy < ApplicationPolicy
   end
 
   def show?
-    super || @user.role?("contributor")
+    super
   end
 
   def create?
@@ -27,7 +27,7 @@ class DueDatePolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      return scope.all if @user.role?("admin") || @user.role?("manager") || @user.role?("contributor")
+      return scope.all if @user.role?("admin") || @user.role?("manager")
       scope.none
     end
   end

--- a/app/policies/indicator_policy.rb
+++ b/app/policies/indicator_policy.rb
@@ -17,7 +17,7 @@ class IndicatorPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      return scope.all if @user.role?("admin") || @user.role?("manager") || @user.role?("contributor")
+      return scope.all if @user.role?("admin") || @user.role?("manager")
       scope.where(draft: false)
     end
   end

--- a/app/policies/measure_policy.rb
+++ b/app/policies/measure_policy.rb
@@ -13,7 +13,7 @@ class MeasurePolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      return scope.all if @user.role?("admin") || @user.role?("manager") || @user.role?("contributor")
+      return scope.all if @user.role?("admin") || @user.role?("manager")
       scope.where(draft: false)
     end
   end

--- a/app/policies/page_policy.rb
+++ b/app/policies/page_policy.rb
@@ -25,7 +25,7 @@ class PagePolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      return scope.all if @user.role?("admin") || @user.role?("manager") || @user.role?("contributor")
+      return scope.all if @user.role?("admin") || @user.role?("manager")
       scope.where(draft: false)
     end
   end

--- a/app/policies/progress_report_policy.rb
+++ b/app/policies/progress_report_policy.rb
@@ -8,16 +8,16 @@ class ProgressReportPolicy < ApplicationPolicy
   end
 
   def create?
-    @user # super || (@user.role?('contributor') && @record.manager == @user)
+    @user
   end
 
   def update?
-    super || (@user.role?("contributor") && @record.manager == @user)
+    super
   end
 
   class Scope < Scope
     def resolve
-      return scope.all if @user.role?("admin") || @user.role?("manager") || @user.role?("contributor")
+      return scope.all if @user.role?("admin") || @user.role?("manager")
       scope.where(draft: false)
     end
   end

--- a/app/policies/recommendation_policy.rb
+++ b/app/policies/recommendation_policy.rb
@@ -14,7 +14,7 @@ class RecommendationPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      return scope.all if @user.role?("admin") || @user.role?("manager") || @user.role?("contributor")
+      return scope.all if @user.role?("admin") || @user.role?("manager")
       scope.where(draft: false)
     end
   end

--- a/app/policies/sdgtarget_policy.rb
+++ b/app/policies/sdgtarget_policy.rb
@@ -7,7 +7,7 @@ class SdgtargetPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      return scope.all if @user.role?("admin") || @user.role?("manager") || @user.role?("contributor")
+      return scope.all if @user.role?("admin") || @user.role?("manager")
       scope.where(draft: false)
     end
   end

--- a/app/policies/user_policy.rb
+++ b/app/policies/user_policy.rb
@@ -28,7 +28,7 @@ class UserPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      return scope.all if @user.role?("admin") || @user.role?("manager") || @user.role?("contributor")
+      return scope.all if @user.role?("admin") || @user.role?("manager")
       scope.where(id: @user.id)
     end
   end

--- a/app/policies/user_role_policy.rb
+++ b/app/policies/user_role_policy.rb
@@ -6,7 +6,7 @@ class UserRolePolicy < ApplicationPolicy
   end
 
   def show?
-    @user.role?("admin") || @user.role?("manager") || @user.role?("contributor")
+    @user.role?("admin") || @user.role?("manager")
   end
 
   def update?
@@ -15,12 +15,12 @@ class UserRolePolicy < ApplicationPolicy
 
   def create?
     return true if @user.role?("admin")
-    @user.role?("manager") && @record.role_name == "contributor" && !(@record.user.role?("admin") || @record.user.role?("manager"))
+    @user.role?("manager") && %w[manager admin].exclude?(@record.role_name) && !(@record.user.role?("admin") || @record.user.role?("manager"))
   end
 
   def destroy?
     return true if @user.role?("admin")
-    @user.role?("manager") && @record.role_name == "contributor" && !(@record.user.role?("admin") || @record.user.role?("manager"))
+    @user.role?("manager") && %w[manager admin].exclude?(@record.role_name) && !(@record.user.role?("admin") || @record.user.role?("manager"))
   end
 
   def permitted_attributes
@@ -32,7 +32,7 @@ class UserRolePolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      return scope.all if @user.role?("admin") || @user.role?("manager") || @user.role?("contributor")
+      return scope.all if @user.role?("admin") || @user.role?("manager")
       scope.where(user_id: @user.id)
     end
   end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -24,7 +24,6 @@ class Seeds
     # Set up user roles
     Role.new(name: "admin", friendly_name: "Admin").save!
     Role.new(name: "manager", friendly_name: "Manager").save!
-    Role.new(name: "contributor", friendly_name: "Contributor").save!
 
     # set up frameworks ########################################################
     fw1 = Framework.new(

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -19,18 +19,11 @@ RSpec.describe CategoriesController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "guest will not see draft categories" do
         sign_in guest
         json = JSON.parse(subject.body)
         expect(json["data"].length).to eq(1)
-      end
-
-      it "contributor will see draft categories" do
-        sign_in contributor
-        json = JSON.parse(subject.body)
-        expect(json["data"].length).to eq(2)
       end
 
       it "manager will see draft categories" do
@@ -51,7 +44,7 @@ RSpec.describe CategoriesController, type: :controller do
 
       it "shows the category" do
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(category.id)
+        expect(json.dig("data", "id").to_i).to eq(category.id)
       end
 
       it "will not show draft category" do

--- a/spec/controllers/due_dates_controller_spec.rb
+++ b/spec/controllers/due_dates_controller_spec.rb
@@ -16,19 +16,12 @@ RSpec.describe DueDatesController, type: :controller do
 
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:user) { FactoryBot.create(:user, :manager) }
 
       it "guest will not see any due_dates" do
         sign_in guest
         json = JSON.parse(subject.body)
         expect(json["data"].length).to eq(0)
-      end
-
-      it "contributor will see all due_dates" do
-        sign_in contributor
-        json = JSON.parse(subject.body)
-        expect(json["data"].length).to eq(2)
       end
 
       it "manager will see all due_dates" do
@@ -65,22 +58,9 @@ RSpec.describe DueDatesController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:indicator) { FactoryBot.create(:indicator) }
-      let(:contributor_indicator) { FactoryBot.create(:indicator, manager: contributor) }
 
-      subject(:with_contributor) do
-        post :create,
-          format: :json,
-          params: {
-            due_date: {
-              due_date: Time.zone.today.to_s,
-              indicator_id: contributor_indicator.id
-            }
-          }
-      end
-
-      subject(:without_contributor) do
+      subject do
         post :create,
           format: :json,
           params: {
@@ -94,16 +74,6 @@ RSpec.describe DueDatesController, type: :controller do
       it "will not allow a guest to create a due_date" do
         sign_in guest
         expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to create a due_date for a indicator they are not a manager for" do
-        sign_in contributor
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to create a due_date for a indicator they are a manager for" do
-        sign_in contributor
-        expect(with_contributor).to be_forbidden
       end
 
       it "will not allow a manager to create a due_date" do
@@ -131,16 +101,10 @@ RSpec.describe DueDatesController, type: :controller do
     context "when user signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "will not allow a guest to update a due_date" do
         sign_in guest
         expect(subject).to be_not_found
-      end
-
-      it "will not allow a contributor to update a due_date" do
-        sign_in contributor
-        expect(subject).to be_forbidden
       end
 
       it "will not allow a manager to update a due_date" do
@@ -162,17 +126,11 @@ RSpec.describe DueDatesController, type: :controller do
 
     context "when user signed in" do
       let(:guest) { FactoryBot.create(:user) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:user) { FactoryBot.create(:user, :manager) }
 
       it "will not allow a guest to delete a due_date" do
         sign_in guest
         expect(subject).to be_not_found
-      end
-
-      it "will not allow a contributor to delete a due_date" do
-        sign_in contributor
-        expect(subject).to be_forbidden
       end
 
       it "will not allow a manager to delete a due_date" do

--- a/spec/controllers/frameworks_controller_spec.rb
+++ b/spec/controllers/frameworks_controller_spec.rb
@@ -3,7 +3,6 @@ require "rails_helper"
 RSpec.describe FrameworksController, type: :controller do
   let!(:guest) { FactoryBot.create(:user) }
   let!(:manager) { FactoryBot.create(:user, :manager) }
-  let!(:contributor) { FactoryBot.create(:user, :contributor) }
 
   describe "index" do
     subject { get :index, format: :json }
@@ -21,12 +20,6 @@ RSpec.describe FrameworksController, type: :controller do
     context "when signed in" do
       it "returns all frameworks for guest" do
         sign_in guest
-        json = JSON.parse(subject.body)
-        expect(framework_count(json)).to eq(3)
-      end
-
-      it "returns all frameworks for contributor" do
-        sign_in contributor
         json = JSON.parse(subject.body)
         expect(framework_count(json)).to eq(3)
       end
@@ -68,19 +61,13 @@ RSpec.describe FrameworksController, type: :controller do
       it "returns the expected framework for guest" do
         sign_in guest
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(framework.id)
-      end
-
-      it "returns the expected framework for contributor" do
-        sign_in contributor
-        json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(framework.id)
+        expect(json.dig("data", "id").to_i).to eq(framework.id)
       end
 
       it "returns the expected framework for manager" do
         sign_in manager
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(framework.id)
+        expect(json.dig("data", "id").to_i).to eq(framework.id)
       end
     end
   end

--- a/spec/controllers/indicators_controller_spec.rb
+++ b/spec/controllers/indicators_controller_spec.rb
@@ -21,18 +21,11 @@ RSpec.describe IndicatorsController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "guest will not see draft indicators" do
         sign_in guest
         json = JSON.parse(subject.body)
         expect(json["data"].length).to eq(1)
-      end
-
-      it "contributor will see draft indicators" do
-        sign_in contributor
-        json = JSON.parse(subject.body)
-        expect(json["data"].length).to eq(2)
       end
 
       it "manager will see draft indicators" do
@@ -66,7 +59,7 @@ RSpec.describe IndicatorsController, type: :controller do
 
       it "shows the indicator" do
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(indicator.id)
+        expect(json.dig("data", "id").to_i).to eq(indicator.id)
       end
 
       it "will not show draft indicator" do
@@ -87,7 +80,6 @@ RSpec.describe IndicatorsController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:measure) { FactoryBot.create(:measure) }
       subject do
         post :create,
@@ -103,11 +95,6 @@ RSpec.describe IndicatorsController, type: :controller do
 
       it "will not allow a guest to create a indicator" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to create a indicator" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 
@@ -147,17 +134,12 @@ RSpec.describe IndicatorsController, type: :controller do
     end
 
     context "when user signed in" do
+      let(:admin) { FactoryBot.create(:user, :admin) }
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "will not allow a guest to update a indicator" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to update a indicator" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 
@@ -197,7 +179,7 @@ RSpec.describe IndicatorsController, type: :controller do
 
       it "will return the latest last_modified_user_id", versioning: true do
         expect(PaperTrail).to be_enabled
-        indicator.versions.first.update_column(:whodunnit, contributor.id)
+        indicator.versions.first.update_column(:whodunnit, admin.id)
         sign_in user
         json = JSON.parse(subject.body)
         expect(json["data"]["attributes"]["last_modified_user_id"].to_i).to eq(user.id)
@@ -224,15 +206,9 @@ RSpec.describe IndicatorsController, type: :controller do
     context "when user signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "will not allow a guest to delete a indicator" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to delete a indicator" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 

--- a/spec/controllers/measure_categories_controller_spec.rb
+++ b/spec/controllers/measure_categories_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe MeasureCategoriesController, type: :controller do
 
       it "shows the measure_category" do
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(measure_category.id)
+        expect(json.dig("data", "id").to_i).to eq(measure_category.id)
       end
     end
   end
@@ -35,7 +35,6 @@ RSpec.describe MeasureCategoriesController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:measure) { FactoryBot.create(:measure) }
       let(:category) { FactoryBot.create(:category) }
 
@@ -52,11 +51,6 @@ RSpec.describe MeasureCategoriesController, type: :controller do
 
       it "will not allow a guest to create a measure_category" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to create a measure_category" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 
@@ -86,15 +80,9 @@ RSpec.describe MeasureCategoriesController, type: :controller do
     context "when user signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "will not allow a guest to delete a measure_category" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to delete a measure_category" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 

--- a/spec/controllers/measure_indicators_controller_spec.rb
+++ b/spec/controllers/measure_indicators_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe MeasureIndicatorsController, type: :controller do
 
       it "shows the measure_indicator" do
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(measure_indicator.id)
+        expect(json.dig("data", "id").to_i).to eq(measure_indicator.id)
       end
     end
   end
@@ -35,7 +35,6 @@ RSpec.describe MeasureIndicatorsController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:measure) { FactoryBot.create(:measure) }
       let(:indicator) { FactoryBot.create(:indicator) }
 
@@ -52,11 +51,6 @@ RSpec.describe MeasureIndicatorsController, type: :controller do
 
       it "will not allow a guest to create a measure_indicator" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to create a measure_indicator" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 
@@ -86,15 +80,9 @@ RSpec.describe MeasureIndicatorsController, type: :controller do
     context "when user signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "will not allow a guest to delete a measure_indicator" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to delete a measure_indicator" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 

--- a/spec/controllers/measures_controller_spec.rb
+++ b/spec/controllers/measures_controller_spec.rb
@@ -21,18 +21,11 @@ RSpec.describe MeasuresController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "guest will not see draft measures" do
         sign_in guest
         json = JSON.parse(subject.body)
         expect(json["data"].length).to eq(1)
-      end
-
-      it "contributor will see draft measures" do
-        sign_in contributor
-        json = JSON.parse(subject.body)
-        expect(json["data"].length).to eq(2)
       end
 
       it "manager will see draft measures" do
@@ -86,7 +79,7 @@ RSpec.describe MeasuresController, type: :controller do
 
       it "shows the measure" do
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(measure.id)
+        expect(json.dig("data", "id").to_i).to eq(measure.id)
       end
 
       it "will not show draft measure" do
@@ -107,7 +100,6 @@ RSpec.describe MeasuresController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:recommendation) { FactoryBot.create(:recommendation) }
       let(:category) { FactoryBot.create(:category) }
 
@@ -136,11 +128,6 @@ RSpec.describe MeasuresController, type: :controller do
 
       it "will not allow a guest to create a measure" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to create a measure" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 
@@ -180,17 +167,12 @@ RSpec.describe MeasuresController, type: :controller do
     end
 
     context "when user signed in" do
+      let(:admin) { FactoryBot.create(:user, :admin) }
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "will not allow a guest to update a measure" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to update a measure" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 
@@ -230,7 +212,7 @@ RSpec.describe MeasuresController, type: :controller do
 
       it "will return the latest last_modified_user_id", versioning: true do
         expect(PaperTrail).to be_enabled
-        measure.versions.first.update_column(:whodunnit, contributor.id)
+        measure.versions.first.update_column(:whodunnit, admin.id)
         sign_in user
         json = JSON.parse(subject.body)
         expect(json["data"]["attributes"]["last_modified_user_id"].to_i).to eq(user.id)
@@ -257,15 +239,9 @@ RSpec.describe MeasuresController, type: :controller do
     context "when user signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "will not allow a guest to delete a measure" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to delete a measure" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -19,18 +19,11 @@ RSpec.describe PagesController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "guest will not see draft pages" do
         sign_in guest
         json = JSON.parse(subject.body)
         expect(json["data"].length).to eq(1)
-      end
-
-      it "contributor will see draft pages" do
-        sign_in contributor
-        json = JSON.parse(subject.body)
-        expect(json["data"].length).to eq(2)
       end
 
       it "manager will see draft pages" do
@@ -51,7 +44,7 @@ RSpec.describe PagesController, type: :controller do
 
       it "shows the page" do
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(page.id)
+        expect(json.dig("data", "id").to_i).to eq(page.id)
       end
 
       it "will not show draft page" do

--- a/spec/controllers/progress_reports_controller_spec.rb
+++ b/spec/controllers/progress_reports_controller_spec.rb
@@ -21,18 +21,11 @@ RSpec.describe ProgressReportsController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:manager) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "guest will not see draft progress_reports" do
         sign_in guest
         json = JSON.parse(subject.body)
         expect(json["data"].length).to eq(1)
-      end
-
-      it "contributor will see draft progress_reports" do
-        sign_in contributor
-        json = JSON.parse(subject.body)
-        expect(json["data"].length).to eq(2)
       end
 
       it "manager will see draft progress_reports" do
@@ -53,7 +46,7 @@ RSpec.describe ProgressReportsController, type: :controller do
 
       it "shows the progress_report" do
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(progress_report.id)
+        expect(json.dig("data", "id").to_i).to eq(progress_report.id)
       end
 
       it "will not show draft progress_report" do
@@ -75,13 +68,11 @@ RSpec.describe ProgressReportsController, type: :controller do
 
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:user) { FactoryBot.create(:user, :manager) }
       let(:due_date) { FactoryBot.create(:due_date) }
       let(:indicator) { FactoryBot.create(:indicator) }
-      let(:contributor_indicator) { FactoryBot.create(:indicator, manager: contributor) }
 
-      subject(:without_contributor_manager) do
+      subject do
         post :create,
           format: :json,
           params: {
@@ -107,35 +98,9 @@ RSpec.describe ProgressReportsController, type: :controller do
         #      }
       end
 
-      subject(:with_contributor_manager) do
-        post :create,
-          format: :json,
-          params: {
-            progress_report: {
-              indicator_id: contributor_indicator.id,
-              due_date_id: due_date.id,
-              title: "test title",
-              description: "test desc",
-              document_url: "test_url",
-              document_public: true
-            }
-          }
-      end
-
       it "will allow a guest to create a progress_report" do
         sign_in guest
         expect(subject).to be_created
-      end
-
-      # This was changed from forbidden in bb687a69339aaa3501f24140907e9a2135ffe4c5 per #154
-      it "will allow a contributor to create a progress_report when they are not a manager for the indicator" do
-        sign_in contributor
-        expect(without_contributor_manager).to be_created
-      end
-
-      it "will allow a contributor to create a progress_report when they are the manager for the indicator" do
-        sign_in contributor
-        expect(with_contributor_manager).to be_created
       end
 
       it "will allow a manager to create a progress_report" do
@@ -161,7 +126,7 @@ RSpec.describe ProgressReportsController, type: :controller do
   describe "PUT update" do
     let(:progress_report) { FactoryBot.create(:progress_report) }
 
-    subject(:without_contributor_manager) do
+    subject do
       put :update,
         format: :json,
         params: {id: progress_report,
@@ -175,32 +140,22 @@ RSpec.describe ProgressReportsController, type: :controller do
     end
 
     context "when user signed in" do
+      let(:admin) { FactoryBot.create(:user, :admin) }
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
-      let(:contributor_indicator) { FactoryBot.create(:indicator, manager: contributor) }
-      let(:progress_report_with_contributor) { FactoryBot.create(:progress_report, indicator: contributor_indicator) }
+      let(:admin_indicator) { FactoryBot.create(:indicator, manager: admin) }
+      let(:progress_report_with_admin) { FactoryBot.create(:progress_report, indicator: admin_indicator) }
 
-      subject(:with_contributor_manager) do
+      subject(:with_admin_manager) do
         put :update,
           format: :json,
-          params: {id: progress_report_with_contributor,
+          params: {id: progress_report_with_admin,
                    progress_report: {title: "test update", description: "test update"}}
       end
 
       it "will not allow a guest to update a progress_report" do
         sign_in guest
         expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to update a progress_report when they are not a manager for the indicator" do
-        sign_in contributor
-        expect(without_contributor_manager).to be_forbidden
-      end
-
-      it "will allow a contributor to update a progress_report when they are the manager for the indicator" do
-        sign_in contributor
-        expect(with_contributor_manager).to be_ok
       end
 
       it "will allow a manager to update a progress_report" do
@@ -210,21 +165,21 @@ RSpec.describe ProgressReportsController, type: :controller do
 
       it "will reject and update where the last_updated_at is older than updated_at in the database" do
         sign_in user
-        progress_report_get = get :show, params: {id: progress_report_with_contributor}, format: :json
+        progress_report_get = get :show, params: {id: progress_report_with_admin}, format: :json
         json = JSON.parse(progress_report_get.body)
         current_update_at = json["data"]["attributes"]["updated_at"]
 
         Timecop.travel(Time.new + 15.days) do
           subject = put :update,
             format: :json,
-            params: {id: progress_report_with_contributor,
+            params: {id: progress_report_with_admin,
                      progress_report: {title: "test update", description: "test updateeee", target_date: "today update", updated_at: current_update_at}}
           expect(subject).to be_ok
         end
         Timecop.travel(Time.new + 5.days) do
           subject = put :update,
             format: :json,
-            params: {id: progress_report_with_contributor,
+            params: {id: progress_report_with_admin,
                      progress_report: {title: "test update", description: "test updatebbbb", target_date: "today update", updated_at: current_update_at}}
           expect(subject).to_not be_ok
         end
@@ -239,7 +194,7 @@ RSpec.describe ProgressReportsController, type: :controller do
 
       it "will return the latest last_modified_user_id", versioning: true do
         expect(PaperTrail).to be_enabled
-        progress_report.versions.first.update_column(:whodunnit, contributor.id)
+        progress_report.versions.first.update_column(:whodunnit, admin.id)
         sign_in user
         json = JSON.parse(subject.body)
         expect(json["data"]["attributes"]["last_modified_user_id"].to_i).to eq(user.id)
@@ -266,15 +221,9 @@ RSpec.describe ProgressReportsController, type: :controller do
     context "when user signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "will not allow a guest to delete a progress_report" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to delete a progress_report" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 

--- a/spec/controllers/recommendation_categories_controller_spec.rb
+++ b/spec/controllers/recommendation_categories_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RecommendationCategoriesController, type: :controller do
 
       it "shows the recommendation_category" do
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(recommendation_category.id)
+        expect(json.dig("data", "id").to_i).to eq(recommendation_category.id)
       end
     end
   end
@@ -35,7 +35,6 @@ RSpec.describe RecommendationCategoriesController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:recommendation) { FactoryBot.create(:recommendation) }
       let(:category) { FactoryBot.create(:category) }
 
@@ -52,11 +51,6 @@ RSpec.describe RecommendationCategoriesController, type: :controller do
 
       it "will not allow a guest to create a recommendation_category" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to create a recommendation_category" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 
@@ -86,15 +80,9 @@ RSpec.describe RecommendationCategoriesController, type: :controller do
     context "when user signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "will not allow a guest to delete a recommendation_category" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to delete a recommendation_category" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 

--- a/spec/controllers/recommendation_indicators_controller_spec.rb
+++ b/spec/controllers/recommendation_indicators_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RecommendationIndicatorsController, type: :controller do
 
       it "returns the recommendation_indicator" do
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(recommendation_indicator.id)
+        expect(json.dig("data", "id").to_i).to eq(recommendation_indicator.id)
       end
     end
   end
@@ -34,7 +34,6 @@ RSpec.describe RecommendationIndicatorsController, type: :controller do
 
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:manager) { FactoryBot.create(:user, :manager) }
       let(:admin) { FactoryBot.create(:user, :admin) }
       let(:recommendation) { FactoryBot.create(:recommendation) }
@@ -53,11 +52,6 @@ RSpec.describe RecommendationIndicatorsController, type: :controller do
 
       it "wont allow a guest to create a recommendation_indicator" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "wont allow a contributor to create a recommendation_indicator" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 
@@ -91,17 +85,11 @@ RSpec.describe RecommendationIndicatorsController, type: :controller do
 
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:manager) { FactoryBot.create(:user, :manager) }
       let(:admin) { FactoryBot.create(:user, :admin) }
 
       it "wont allow a guest to delete a recommendation_indicator" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "wont allow a contributor to delete a recommendation_indicator" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 

--- a/spec/controllers/recommendation_measures_controller_spec.rb
+++ b/spec/controllers/recommendation_measures_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RecommendationMeasuresController, type: :controller do
 
       it "shows the recommendation_measure" do
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(recommendation_measure.id)
+        expect(json.dig("data", "id").to_i).to eq(recommendation_measure.id)
       end
     end
   end

--- a/spec/controllers/recommendation_recommendations_controller_spec.rb
+++ b/spec/controllers/recommendation_recommendations_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe RecommendationRecommendationsController, type: :controller do
 
       it "shows the recommendation_recommendation" do
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(recommendation_recommendation.id)
+        expect(json.dig("data", "id").to_i).to eq(recommendation_recommendation.id)
       end
     end
   end
@@ -34,7 +34,6 @@ RSpec.describe RecommendationRecommendationsController, type: :controller do
 
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:manager) { FactoryBot.create(:user, :manager) }
       let(:admin) { FactoryBot.create(:user, :admin) }
       let(:recommendation_1) { FactoryBot.create(:recommendation) }
@@ -53,11 +52,6 @@ RSpec.describe RecommendationRecommendationsController, type: :controller do
 
       it "wont allow a guest to create a recommendation_recommendation" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "wont allow a contributor to create a recommendation_recommendation" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 
@@ -92,16 +86,10 @@ RSpec.describe RecommendationRecommendationsController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:manager) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:admin) { FactoryBot.create(:user, :admin) }
 
       it "will not allow a guest to delete a recommendation_recommendation" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to delete a recommendation_recommendation" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 

--- a/spec/controllers/recommendations_controller_spec.rb
+++ b/spec/controllers/recommendations_controller_spec.rb
@@ -21,18 +21,11 @@ RSpec.describe RecommendationsController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "guest will not see draft recommendations" do
         sign_in guest
         json = JSON.parse(subject.body)
         expect(json["data"].length).to eq(1)
-      end
-
-      it "contributor will see draft recommendations" do
-        sign_in contributor
-        json = JSON.parse(subject.body)
-        expect(json["data"].length).to eq(2)
       end
 
       it "manager will see draft recommendations" do
@@ -76,7 +69,7 @@ RSpec.describe RecommendationsController, type: :controller do
 
       it "shows the recommendation" do
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(recommendation.id)
+        expect(json.dig("data", "id").to_i).to eq(recommendation.id)
       end
 
       it "will not show draft recommendation" do
@@ -97,7 +90,6 @@ RSpec.describe RecommendationsController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:category) { FactoryBot.create(:category) }
       subject do
         post :create,
@@ -112,11 +104,6 @@ RSpec.describe RecommendationsController, type: :controller do
 
       it "will not allow a guest to create a recommendation" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to create a recommendation" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 
@@ -156,17 +143,12 @@ RSpec.describe RecommendationsController, type: :controller do
     end
 
     context "when user signed in" do
+      let(:admin) { FactoryBot.create(:user, :admin) }
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "will not allow a guest to update a recommendation" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to update a recommendation" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 
@@ -206,7 +188,7 @@ RSpec.describe RecommendationsController, type: :controller do
 
       it "will return the latest last_modified_user_id", versioning: true do
         expect(PaperTrail).to be_enabled
-        recommendation.versions.first.update_column(:whodunnit, contributor.id)
+        recommendation.versions.first.update_column(:whodunnit, admin.id)
         sign_in user
         json = JSON.parse(subject.body)
         expect(json["data"]["attributes"]["last_modified_user_id"].to_i).to eq(user.id)
@@ -233,15 +215,9 @@ RSpec.describe RecommendationsController, type: :controller do
     context "when user signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "will not allow a guest to delete a recommendation" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to delete a recommendation" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 

--- a/spec/controllers/roles_controller.rb
+++ b/spec/controllers/roles_controller.rb
@@ -20,19 +20,12 @@ RSpec.describe RolesController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:admin) { FactoryBot.create(:user, :admin) }
 
       it "guest will see roles" do
         sign_in guest
         json = JSON.parse(subject.body)
         expect(json["data"].length).to eq(1)
-      end
-
-      it "contributor will see roles" do
-        sign_in contributor
-        json = JSON.parse(subject.body)
-        expect(json["data"].length).to eq(2)
       end
 
       it "manager will see roles" do
@@ -58,7 +51,7 @@ RSpec.describe RolesController, type: :controller do
 
       it "shows the role" do
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(role.id)
+        expect(json.dig("data", "id").to_i).to eq(role.id)
       end
     end
   end
@@ -73,7 +66,6 @@ RSpec.describe RolesController, type: :controller do
 
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:manager) { FactoryBot.create(:user, :manager) }
       let(:admin) { FactoryBot.create(:user, :admin) }
 
@@ -83,11 +75,6 @@ RSpec.describe RolesController, type: :controller do
 
       it "will not allow a guest to create a role" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to create a role" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 
@@ -119,17 +106,11 @@ RSpec.describe RolesController, type: :controller do
 
     context "when user signed in" do
       let(:guest) { FactoryBot.create(:user) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:manager) { FactoryBot.create(:user, :manager) }
       let(:admin) { FactoryBot.create(:user, :admin) }
 
       it "will not allow a guest to update a measure" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to update a role" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 
@@ -158,16 +139,10 @@ RSpec.describe RolesController, type: :controller do
     context "when user signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:manager) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:admin) { FactoryBot.create(:user, :admin) }
 
       it "will not allow a guest to delete a role" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to delete a role" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 

--- a/spec/controllers/sdgtarget_categories_controller_spec.rb
+++ b/spec/controllers/sdgtarget_categories_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SdgtargetCategoriesController, type: :controller do
 
       it "shows the sdgtarget_category" do
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(sdgtarget_category.id)
+        expect(json.dig("data", "id").to_i).to eq(sdgtarget_category.id)
       end
     end
   end
@@ -35,7 +35,6 @@ RSpec.describe SdgtargetCategoriesController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:sdgtarget) { FactoryBot.create(:sdgtarget) }
       let(:category) { FactoryBot.create(:category) }
 
@@ -52,11 +51,6 @@ RSpec.describe SdgtargetCategoriesController, type: :controller do
 
       it "will not allow a guest to create a sdgtarget_category" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to create a sdgtarget_category" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 
@@ -86,15 +80,9 @@ RSpec.describe SdgtargetCategoriesController, type: :controller do
     context "when user signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "will not allow a guest to delete a sdgtarget_category" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to delete a sdgtarget_category" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 

--- a/spec/controllers/sdgtarget_indicators_controller_spec.rb
+++ b/spec/controllers/sdgtarget_indicators_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SdgtargetIndicatorsController, type: :controller do
 
       it "shows the sdgtarget_indicator" do
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(sdgtarget_indicator.id)
+        expect(json.dig("data", "id").to_i).to eq(sdgtarget_indicator.id)
       end
     end
   end
@@ -35,7 +35,6 @@ RSpec.describe SdgtargetIndicatorsController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:sdgtarget) { FactoryBot.create(:sdgtarget) }
       let(:indicator) { FactoryBot.create(:indicator) }
 
@@ -52,11 +51,6 @@ RSpec.describe SdgtargetIndicatorsController, type: :controller do
 
       it "will not allow a guest to create a sdgtarget_indicator" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to create a sdgtarget_indicator" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 
@@ -86,15 +80,9 @@ RSpec.describe SdgtargetIndicatorsController, type: :controller do
     context "when user signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "will not allow a guest to delete a sdgtarget_indicator" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to delete a sdgtarget_indicator" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 

--- a/spec/controllers/sdgtarget_measures_controller_spec.rb
+++ b/spec/controllers/sdgtarget_measures_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SdgtargetMeasuresController, type: :controller do
 
       it "shows the sdgtarget_measure" do
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(sdgtarget_measure.id)
+        expect(json.dig("data", "id").to_i).to eq(sdgtarget_measure.id)
       end
     end
   end
@@ -35,7 +35,6 @@ RSpec.describe SdgtargetMeasuresController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:sdgtarget) { FactoryBot.create(:sdgtarget) }
       let(:measure) { FactoryBot.create(:measure) }
 
@@ -52,11 +51,6 @@ RSpec.describe SdgtargetMeasuresController, type: :controller do
 
       it "will not allow a guest to create a sdgtarget_measure" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to create a sdgtarget_measure" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 
@@ -86,15 +80,9 @@ RSpec.describe SdgtargetMeasuresController, type: :controller do
     context "when user signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "will not allow a guest to delete a sdgtarget_measure" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to delete a sdgtarget_measure" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 

--- a/spec/controllers/sdgtarget_recommendations_controller_spec.rb
+++ b/spec/controllers/sdgtarget_recommendations_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe SdgtargetRecommendationsController, type: :controller do
 
       it "shows the sdgtarget_recommendation" do
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(sdgtarget_recommendation.id)
+        expect(json.dig("data", "id").to_i).to eq(sdgtarget_recommendation.id)
       end
     end
   end
@@ -35,7 +35,6 @@ RSpec.describe SdgtargetRecommendationsController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:sdgtarget) { FactoryBot.create(:sdgtarget) }
       let(:recommendation) { FactoryBot.create(:recommendation) }
 
@@ -52,11 +51,6 @@ RSpec.describe SdgtargetRecommendationsController, type: :controller do
 
       it "will not allow a guest to create a sdgtarget_recommendation" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to create a sdgtarget_recommendation" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 
@@ -86,15 +80,9 @@ RSpec.describe SdgtargetRecommendationsController, type: :controller do
     context "when user signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "will not allow a guest to delete a sdgtarget_recommendation" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to delete a sdgtarget_recommendation" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 

--- a/spec/controllers/sdgtargets_controller_spec.rb
+++ b/spec/controllers/sdgtargets_controller_spec.rb
@@ -21,18 +21,11 @@ RSpec.describe SdgtargetsController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "guest will not see draft sdgtargets" do
         sign_in guest
         json = JSON.parse(subject.body)
         expect(json["data"].length).to eq(1)
-      end
-
-      it "contributor will see draft sdgtargets" do
-        sign_in contributor
-        json = JSON.parse(subject.body)
-        expect(json["data"].length).to eq(2)
       end
 
       it "manager will see draft sdgtargets" do
@@ -53,7 +46,7 @@ RSpec.describe SdgtargetsController, type: :controller do
 
       it "shows the sdgtarget" do
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(sdgtarget.id)
+        expect(json.dig("data", "id").to_i).to eq(sdgtarget.id)
       end
 
       it "will not show draft sdgtarget" do
@@ -74,7 +67,6 @@ RSpec.describe SdgtargetsController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:recommendation) { FactoryBot.create(:recommendation) }
       let(:category) { FactoryBot.create(:category) }
 
@@ -103,11 +95,6 @@ RSpec.describe SdgtargetsController, type: :controller do
 
       it "will not allow a guest to create a sdgtarget" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to create a sdgtarget" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 
@@ -147,17 +134,12 @@ RSpec.describe SdgtargetsController, type: :controller do
     end
 
     context "when user signed in" do
+      let(:admin) { FactoryBot.create(:user, :admin) }
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "will not allow a guest to update a sdgtarget" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to update a sdgtarget" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 
@@ -197,7 +179,7 @@ RSpec.describe SdgtargetsController, type: :controller do
 
       it "will return the latest last_modified_user_id", versioning: true do
         expect(PaperTrail).to be_enabled
-        sdgtarget.versions.first.update_column(:whodunnit, contributor.id)
+        sdgtarget.versions.first.update_column(:whodunnit, admin.id)
         sign_in user
         json = JSON.parse(subject.body)
         expect(json["data"]["attributes"]["last_modified_user_id"].to_i).to eq(user.id)
@@ -224,15 +206,9 @@ RSpec.describe SdgtargetsController, type: :controller do
     context "when user signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "will not allow a guest to delete a sdgtarget" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to delete a sdgtarget" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 

--- a/spec/controllers/taxonomies_controller_spec.rb
+++ b/spec/controllers/taxonomies_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe TaxonomiesController, type: :controller do
 
       it "shows the taxonomy" do
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(taxonomy.id)
+        expect(json.dig("data", "id").to_i).to eq(taxonomy.id)
       end
     end
   end
@@ -41,7 +41,6 @@ RSpec.describe TaxonomiesController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:taxonomy) { FactoryBot.create(:taxonomy) }
 
       subject do
@@ -62,11 +61,6 @@ RSpec.describe TaxonomiesController, type: :controller do
 
       it "will not allow a guest to create a taxonomy" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to create a taxonomy" do
-        sign_in user
         expect(subject).to be_forbidden
       end
 
@@ -94,16 +88,10 @@ RSpec.describe TaxonomiesController, type: :controller do
 
     context "when user signed in" do
       let(:guest) { FactoryBot.create(:user) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:user) { FactoryBot.create(:user, :manager) }
 
       it "will not allow a guest to update a taxonomy" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to update a taxonomy" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 
@@ -127,15 +115,9 @@ RSpec.describe TaxonomiesController, type: :controller do
     context "when user signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "will not allow a guest to delete a taxonomy" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to delete a taxonomy" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 

--- a/spec/controllers/user_categories_controller_spec.rb
+++ b/spec/controllers/user_categories_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe UserCategoriesController, type: :controller do
 
       it "shows the user_category" do
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(user_category.id)
+        expect(json.dig("data", "id").to_i).to eq(user_category.id)
       end
     end
   end
@@ -35,7 +35,6 @@ RSpec.describe UserCategoriesController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:manager) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:user) { FactoryBot.create(:user) }
       let(:category) { FactoryBot.create(:category) }
 
@@ -52,11 +51,6 @@ RSpec.describe UserCategoriesController, type: :controller do
 
       it "will not allow a guest to create a user_category" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to create a user_category" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 
@@ -86,15 +80,9 @@ RSpec.describe UserCategoriesController, type: :controller do
     context "when user signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
 
       it "will not allow a guest to delete a user_category" do
         sign_in guest
-        expect(subject).to be_forbidden
-      end
-
-      it "will not allow a contributor to delete a user_category" do
-        sign_in contributor
         expect(subject).to be_forbidden
       end
 

--- a/spec/controllers/user_roles_controller_spec.rb
+++ b/spec/controllers/user_roles_controller_spec.rb
@@ -17,9 +17,6 @@ RSpec.describe UserRolesController, type: :controller do
       let(:manager_role) { FactoryBot.create(:role, :manager) }
       let(:manager) { FactoryBot.create(:user, roles: [manager_role]) }
       let(:manager2) { FactoryBot.create(:user, roles: [manager_role]) }
-      let(:contributor_role) { FactoryBot.create(:role, :contributor) }
-      let(:contributor) { FactoryBot.create(:user, roles: [contributor_role]) }
-      let(:contributor2) { FactoryBot.create(:user, roles: [contributor_role]) }
       let(:admin_role) { FactoryBot.create(:role, :admin) }
       let(:admin) { FactoryBot.create(:user, roles: [admin_role]) }
       let(:admin2) { FactoryBot.create(:user, roles: [admin_role]) }
@@ -30,47 +27,28 @@ RSpec.describe UserRolesController, type: :controller do
         expect(json["data"].length).to eq(0)
       end
 
-      it "shows all users roles for contributors" do
-        contributor
-        contributor2
-        manager
-        manager2
-        admin
-        admin2
-        sign_in contributor
-        json = JSON.parse(subject.body)
-        expect(json["data"].length).to eq(6)
-        returned_roles = json["data"].map { |user_role| user_role["attributes"]["role_id"] }.uniq
-        permitted_roles = [contributor.roles.first.id, manager.roles.first.id]
-        expect(permitted_roles - returned_roles).to be_empty
-      end
-
       it "shows all users roles for managers" do
-        contributor
-        contributor2
         manager
         manager2
         admin
         admin2
         sign_in manager
         json = JSON.parse(subject.body)
-        expect(json["data"].length).to eq(6)
+        expect(json["data"].length).to eq(4)
         returned_roles = json["data"].map { |user_role| user_role["attributes"]["role_id"] }.uniq
-        permitted_roles = [contributor.roles.first.id, manager.roles.first.id]
+        permitted_roles = [manager.roles.first.id]
         expect(permitted_roles - returned_roles).to be_empty
       end
 
       it "shows all user roles for admin" do
-        contributor
-        contributor2
         manager
         manager2
         admin2
         sign_in admin
         json = JSON.parse(subject.body)
-        expect(json["data"].length).to eq(6)
+        expect(json["data"].length).to eq(4)
         returned_roles = json["data"].map { |user_role| user_role["attributes"]["role_id"] }.uniq
-        permitted_roles = [contributor.roles.first.id, manager.roles.first.id]
+        permitted_roles = [manager.roles.first.id]
         expect(permitted_roles - returned_roles).to be_empty
       end
     end
@@ -89,36 +67,31 @@ RSpec.describe UserRolesController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:manager) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:admin) { FactoryBot.create(:user, :admin) }
 
-      subject { get :show, params: {id: contributor.user_roles.first.id}, format: :json }
+      subject { get :show, params: {id: manager.user_roles.first.id}, format: :json }
 
       let(:guest) { FactoryBot.create(:user) }
       let(:manager) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:admin) { FactoryBot.create(:user, :admin) }
 
       it "shows no user_role for guest" do
         sign_in guest
         expect(subject).to be_not_found
       end
-      it "shows user_role for contributor" do
-        sign_in contributor
-        json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(contributor.user_roles.first.id)
-      end
+
       it "shows user_role for manager" do
         sign_in manager
         subject_manager = get :show, params: {id: manager.user_roles.first.id}, format: :json
         json = JSON.parse(subject_manager.body)
-        expect(json["data"]["id"].to_i).to eq(manager.user_roles.first.id)
+        expect(json.dig("data", "id").to_i).to eq(manager.user_roles.first.id)
       end
+
       it "shows user_role for admin" do
         sign_in admin
         subject_manager = get :show, params: {id: admin.user_roles.first.id}, format: :json
         json = JSON.parse(subject_manager.body)
-        expect(json["data"]["id"].to_i).to eq(admin.user_roles.first.id)
+        expect(json.dig("data", "id").to_i).to eq(admin.user_roles.first.id)
       end
     end
   end
@@ -135,8 +108,6 @@ RSpec.describe UserRolesController, type: :controller do
       let(:guest) { FactoryBot.create(:user) }
       let(:manager_role) { FactoryBot.create(:role, :manager) }
       let(:manager) { FactoryBot.create(:user, roles: [manager_role]) }
-      let(:contributor_role) { FactoryBot.create(:role, :contributor) }
-      let(:contributor) { FactoryBot.create(:user, roles: [contributor_role]) }
       let(:admin_role) { FactoryBot.create(:role, :admin) }
       let(:admin) { FactoryBot.create(:user, roles: [admin_role]) }
 
@@ -146,7 +117,7 @@ RSpec.describe UserRolesController, type: :controller do
           params: {
             user_role: {
               user_id: guest.id,
-              role_id: contributor_role.id
+              role_id: manager.id
             }
           }
       end
@@ -156,88 +127,42 @@ RSpec.describe UserRolesController, type: :controller do
         expect(subject).to be_forbidden
       end
 
-      it "will not allow a contributor to create a contributor, manager, or admin user_role" do
-        sign_in contributor
-        subject = post :create,
-          format: :json,
-          params: {
-            user_role: {
-              user_id: guest.id,
-              role_id: contributor_role.id
-            }
-          }
-        expect(subject).to be_forbidden
-        subject = post :create,
-          format: :json,
-          params: {
-            user_role: {
-              user_id: guest.id,
-              role_id: manager_role.id
-            }
-          }
-        expect(subject).to be_forbidden
-        subject = post :create,
-          format: :json,
-          params: {
-            user_role: {
-              user_id: guest.id,
-              role_id: admin_role.id
-            }
-          }
-        expect(subject).to be_forbidden
-      end
-
-      it "will allow a manager to create a contributor but not a manager or admin user_role" do
+      it "will not allow a manager to create a manager or admin user_role" do
         sign_in manager
-        subject = post :create,
-          format: :json,
-          params: {
-            user_role: {
-              user_id: contributor.id,
-              role_id: manager_role.id
-            }
-          }
-        expect(subject).to be_forbidden
-        subject = post :create,
-          format: :json,
-          params: {
-            user_role: {
-              user_id: contributor.id,
-              role_id: admin_role.id
-            }
-          }
-        expect(subject).to be_forbidden
-        subject = post :create,
+
+        expect(post(:create,
           format: :json,
           params: {
             user_role: {
               user_id: guest.id,
-              role_id: contributor_role.id
+              role_id: manager_role.id
             }
-          }
-        expect(subject).to be_created
+          })).to be_forbidden
+
+        expect(
+          post(:create,
+            format: :json,
+            params: {
+              user_role: {
+                user_id: guest.id,
+                role_id: admin_role.id
+              }
+            })
+        ).to be_forbidden
       end
 
-      it "will allow an admin to create a manager, contributor, or admin admin user_role" do
+      it "will allow an admin to create a manager, or admin admin user_role" do
         sign_in admin
         subject = post :create,
           format: :json,
           params: {
             user_role: {
-              user_id: contributor.id,
+              user_id: guest.id,
               role_id: manager_role.id
             }
           }
         expect(subject).to be_created
-        subject = post :create,
-          format: :json,
-          params: {
-            user_role: {
-              user_id: manager.id,
-              role_id: contributor_role.id
-            }
-          }
-        expect(subject).to be_created
+
         subject = post :create,
           format: :json,
           params: {
@@ -262,15 +187,11 @@ RSpec.describe UserRolesController, type: :controller do
     let(:manager_role) { FactoryBot.create(:role, :manager) }
     let(:manager) { FactoryBot.create(:user, roles: [manager_role]) }
     let(:manager_role2) { FactoryBot.create(:role, :manager) }
-    let(:manager2) { FactoryBot.create(:user, roles: [contributor_role, manager_role2]) }
-    let(:contributor_role) { FactoryBot.create(:role, :contributor) }
-    let(:contributor_role2) { FactoryBot.create(:role, :contributor) }
-    let(:contributor) { FactoryBot.create(:user, roles: [contributor_role]) }
-    let(:contributor2) { FactoryBot.create(:user, roles: [contributor_role2]) }
+    let(:manager2) { FactoryBot.create(:user, roles: [manager_role2]) }
     let(:admin_role) { FactoryBot.create(:role, :admin) }
-    let(:admin) { FactoryBot.create(:user, roles: [admin_role, contributor_role]) }
+    let(:admin) { FactoryBot.create(:user, roles: [admin_role, manager_role]) }
 
-    subject { delete :destroy, format: :json, params: {id: contributor.user_roles.first} }
+    subject { delete :destroy, format: :json, params: {id: manager.user_roles.first} }
 
     context "when not signed in" do
       it "not allow deleting a user_role" do
@@ -284,26 +205,18 @@ RSpec.describe UserRolesController, type: :controller do
         expect(subject).to be_not_found
       end
 
-      it "will not allow a contributor to delete a user_role" do
-        sign_in contributor
-        expect(subject).to be_forbidden
-      end
-
-      it "will allow a manager to delete a contributor user_role but not for an admin or another manager" do
+      it "will not allow a manager to delete an admin or another manager" do
         sign_in manager
-        subject = delete :destroy, format: :json, params: {id: contributor.user_roles.first}
-        expect(subject).to be_no_content
-        subject = delete :destroy, format: :json, params: {id: manager2.user_roles.find_by(role_id: contributor_role.id)}
+
+        subject = delete :destroy, format: :json, params: {id: manager2.user_roles.find_by(role_id: manager_role2.id)}
         expect(subject).to be_forbidden
-        subject = delete :destroy, format: :json, params: {id: admin.user_roles.find_by(role_id: contributor_role.id)}
+        subject = delete :destroy, format: :json, params: {id: admin.user_roles.find_by(role_id: manager_role.id)}
         expect(subject).to be_forbidden
       end
 
-      it "will allow an admin to delete a manager, contributor, and admin user_role" do
+      it "will allow an admin to delete a manager, and admin user_role" do
         sign_in admin
         subject = delete :destroy, format: :json, params: {id: manager.user_roles.first}
-        expect(subject).to be_no_content
-        subject = delete :destroy, format: :json, params: {id: contributor2.user_roles.first}
         expect(subject).to be_no_content
         subject = delete :destroy, format: :json, params: {id: admin.user_roles.first}
         expect(subject).to be_no_content

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -12,13 +12,10 @@ RSpec.describe UsersController, type: :controller do
       let(:guest) { FactoryBot.create(:user) }
       let(:manager) { FactoryBot.create(:user, :manager) }
       let(:manager2) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
-      let(:contributor2) { FactoryBot.create(:user, :contributor) }
       let(:admin) { FactoryBot.create(:user, :admin) }
       let(:admin2) { FactoryBot.create(:user, :admin) }
 
       it "shows only themselves for guests" do
-        contributor2
         manager
         admin
         sign_in guest
@@ -27,22 +24,7 @@ RSpec.describe UsersController, type: :controller do
         expect(json["data"][0]["id"]).to eq(guest.id.to_s)
       end
 
-      it "shows all users for contributors" do
-        contributor
-        contributor2
-        manager
-        manager2
-        admin
-        admin2
-        guest
-        sign_in contributor
-        json = JSON.parse(subject.body)
-        expect(json["data"].length).to eq(7)
-      end
-
       it "shows all users for managers" do
-        contributor
-        contributor2
         manager
         manager2
         admin
@@ -50,19 +32,17 @@ RSpec.describe UsersController, type: :controller do
         guest
         sign_in manager
         json = JSON.parse(subject.body)
-        expect(json["data"].length).to eq(7)
+        expect(json["data"].length).to eq(5)
       end
 
       it "shows all users for admin" do
-        contributor
-        contributor2
         manager
         manager2
         admin2
         guest
         sign_in admin
         json = JSON.parse(subject.body)
-        expect(json["data"].length).to eq(7)
+        expect(json["data"].length).to eq(5)
       end
     end
   end
@@ -80,45 +60,39 @@ RSpec.describe UsersController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:manager) { FactoryBot.create(:user, :manager) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:admin) { FactoryBot.create(:user, :admin) }
 
-      subject { get :show, params: {id: contributor.id}, format: :json }
+      subject { get :show, params: {id: manager.id}, format: :json }
 
       it "shows no user for guest" do
         sign_in guest
         expect(subject).to be_not_found
       end
-      it "shows user for contributor" do
-        sign_in contributor
-        json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(contributor.id)
-      end
+
       it "shows user for manager" do
         sign_in manager
         subject_manager = get :show, params: {id: manager.id}, format: :json
         json = JSON.parse(subject_manager.body)
-        expect(json["data"]["id"].to_i).to eq(manager.id)
+        expect(json.dig("data", "id").to_i).to eq(manager.id)
       end
+
       it "shows user for admin" do
         sign_in admin
         subject_manager = get :show, params: {id: admin.id}, format: :json
         json = JSON.parse(subject_manager.body)
-        expect(json["data"]["id"].to_i).to eq(admin.id)
+        expect(json.dig("data", "id").to_i).to eq(admin.id)
       end
     end
   end
 
   describe "PUT update" do
-    let(:guest) { FactoryBot.create(:user, :contributor) }
-    let(:contributor) { FactoryBot.create(:user, :contributor) }
-    let(:manager) { FactoryBot.create(:user, :contributor) }
-    let(:contributor2) { FactoryBot.create(:user, :contributor) }
+    let(:guest) { FactoryBot.create(:user) }
+    let(:manager) { FactoryBot.create(:user, :manager) }
     let(:admin) { FactoryBot.create(:user, :admin) }
     subject do
       put :update,
         format: :json,
-        params: {id: contributor.id, user: {email: "test@co.nz", password: "testtest", name: "Sam"}}
+        params: {id: manager.id, user: {email: "test@co.nz", password: "testtest", name: "Sam"}}
     end
 
     context "when not signed in" do
@@ -130,7 +104,6 @@ RSpec.describe UsersController, type: :controller do
     context "when user signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user) }
-      let(:contributor) { FactoryBot.create(:user, :contributor) }
       let(:manager) { FactoryBot.create(:user, :manager) }
       let(:manager2) { FactoryBot.create(:user, :manager) }
       let(:admin) { FactoryBot.create(:user, :admin) }
@@ -140,28 +113,28 @@ RSpec.describe UsersController, type: :controller do
         expect(subject).to be_not_found
       end
       it "will allow a user to update themselves" do
-        sign_in contributor
-        expect(subject).to be_ok
-        json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(contributor.id)
-        expect(json["data"]["attributes"]["email"]).to eq "test@co.nz"
-        expect(json["data"]["attributes"]["name"]).to eq "Sam"
-      end
-      it "will allow a an manager to update themself, contributors, and guests" do
         sign_in manager
         expect(subject).to be_ok
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(contributor.id)
-        expect(json["data"]["attributes"]["email"]).to eq "test@co.nz"
-        expect(json["data"]["attributes"]["name"]).to eq "Sam"
+        expect(json.dig("data", "id").to_i).to eq(manager.id)
+        expect(json.dig("data", "attributes", "email")).to eq "test@co.nz"
+        expect(json.dig("data", "attributes", "name")).to eq "Sam"
+      end
+      it "will allow a an manager to update themselves, and guests" do
+        sign_in manager
+        expect(subject).to be_ok
+        json = JSON.parse(subject.body)
+        expect(json.dig("data", "id").to_i).to eq(manager.id)
+        expect(json.dig("data", "attributes", "email")).to eq "test@co.nz"
+        expect(json.dig("data", "attributes", "name")).to eq "Sam"
         subject2 = put :update,
           format: :json,
           params: {id: guest.id, user: {email: "test@co.guest.nz", password: "testtest", name: "Sam"}}
         expect(subject2).to be_ok
         json = JSON.parse(subject2.body)
-        expect(json["data"]["id"].to_i).to eq(guest.id)
-        expect(json["data"]["attributes"]["email"]).to eq "test@co.guest.nz"
-        expect(json["data"]["attributes"]["name"]).to eq "Sam"
+        expect(json.dig("data", "id").to_i).to eq(guest.id)
+        expect(json.dig("data", "attributes", "email")).to eq "test@co.guest.nz"
+        expect(json.dig("data", "attributes", "name")).to eq "Sam"
       end
       it "will not allow a an manager to another manager or admin" do
         sign_in manager
@@ -178,16 +151,16 @@ RSpec.describe UsersController, type: :controller do
         sign_in admin
         expect(subject).to be_ok
         json = JSON.parse(subject.body)
-        expect(json["data"]["id"].to_i).to eq(contributor.id)
-        expect(json["data"]["attributes"]["email"]).to eq "test@co.nz"
-        expect(json["data"]["attributes"]["name"]).to eq "Sam"
+        expect(json.dig("data", "id").to_i).to eq(manager.id)
+        expect(json.dig("data", "attributes", "email")).to eq "test@co.nz"
+        expect(json.dig("data", "attributes", "name")).to eq "Sam"
       end
 
       it "will record what manager updated the user", versioning: true do
         expect(PaperTrail).to be_enabled
         sign_in admin
         json = JSON.parse(subject.body)
-        expect(json["data"]["attributes"]["last_modified_user_id"].to_i).to eq admin.id
+        expect(json.dig("data", "attributes", "last_modified_user_id").to_i).to eq admin.id
       end
     end
   end
@@ -196,10 +169,6 @@ RSpec.describe UsersController, type: :controller do
     let(:guest) { FactoryBot.create(:user) }
     let(:manager_role) { FactoryBot.create(:role, :manager) }
     let(:manager) { FactoryBot.create(:user, roles: [manager_role]) }
-    let(:contributor_role) { FactoryBot.create(:role, :contributor) }
-    let(:contributor_role2) { FactoryBot.create(:role, :contributor) }
-    let(:contributor) { FactoryBot.create(:user, roles: [contributor_role]) }
-    let(:contributor2) { FactoryBot.create(:user, roles: [contributor_role2]) }
     let(:admin_role) { FactoryBot.create(:role, :admin) }
     let(:admin) { FactoryBot.create(:user, roles: [admin_role]) }
 
@@ -219,8 +188,8 @@ RSpec.describe UsersController, type: :controller do
       end
 
       it "will allow a user to delete themselves" do
-        sign_in contributor
-        subject = delete :destroy, format: :json, params: {id: contributor.id}
+        sign_in manager
+        subject = delete :destroy, format: :json, params: {id: manager.id}
         expect(subject).to be_no_content
       end
 

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -10,9 +10,5 @@ FactoryBot.define do
     trait :manager do
       name { "manager" }
     end
-
-    trait :contributor do
-      name { "contributor" }
-    end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -15,8 +15,4 @@ FactoryBot.define do
   trait :manager do
     roles { [create(:role, :manager)] }
   end
-
-  trait :contributor do
-    roles { [create(:role, :contributor)] }
-  end
 end


### PR DESCRIPTION
Building on #13 this completely removes the contributor role, rather
than just disabling it in the seeds file.