### PR TITLE
Update `sass-rails` and `web-console` gems

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem "pg", "~> 1.2"
 gem "pundit"
 gem "rack-cors", require: "rack/cors"
 gem "rails", "~> 6.0"
-gem "sass-rails", "~> 5.0"
+gem "sass-rails", "~> 6.0"
 gem "secure_headers", ">= 3.0"
 
 group :production, :staging do
@@ -38,7 +38,7 @@ group :development do
   gem "spring"
   gem "standard"
   gem "thin", require: false
-  gem "web-console", "~> 2.0"
+  gem "web-console", "~> 4.1"
 end
 
 group :development, :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,7 @@ GEM
       coderay (>= 1.0.0)
       erubi (>= 1.0.0)
       rack (>= 0.9.0)
+    bindex (0.8.1)
     binding_of_caller (1.0.0)
       debug_inspector (>= 0.0.1)
     brakeman (5.1.1)
@@ -323,12 +324,16 @@ GEM
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
-    sass-rails (5.1.0)
-      railties (>= 5.2.0)
-      sass (~> 3.1)
-      sprockets (>= 2.8, < 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
-      tilt (>= 1.1, < 3)
+    sass-rails (6.0.0)
+      sassc-rails (~> 2.1, >= 2.1.1)
+    sassc (2.4.0)
+      ffi (~> 1.9)
+    sassc-rails (2.1.2)
+      railties (>= 4.0.0)
+      sassc (>= 2.0)
+      sprockets (> 3.0)
+      sprockets-rails
+      tilt
     secure_headers (6.3.3)
     shoulda-matchers (5.0.0)
       activesupport (>= 5.2.0)
@@ -373,11 +378,11 @@ GEM
       unicorn (>= 4, < 7)
     warden (1.2.9)
       rack (>= 2.0.9)
-    web-console (2.3.0)
-      activemodel (>= 4.0)
-      binding_of_caller (>= 0.7.2)
-      railties (>= 4.0)
-      sprockets-rails (>= 2.0, < 4.0)
+    web-console (4.1.0)
+      actionview (>= 6.0.0)
+      activemodel (>= 6.0.0)
+      bindex (>= 0.4.0)
+      railties (>= 6.0.0)
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
@@ -424,7 +429,7 @@ DEPENDENCIES
   rack-cors
   rails (~> 6.0)
   rspec-rails
-  sass-rails (~> 5.0)
+  sass-rails (~> 6.0)
   secure_headers (>= 3.0)
   shoulda-matchers
   simplecov
@@ -434,7 +439,7 @@ DEPENDENCIES
   timecop
   unicorn
   unicorn-worker-killer
-  web-console (~> 2.0)
+  web-console (~> 4.1)
 
 RUBY VERSION
    ruby 3.0.2p107


### PR DESCRIPTION
Whenever there was a 500, `web-console` was presenting errors due to
missing `Mime::HTML`, but this is resolved by installing the latest
version.

This also updates `sass-rails` from 5.x to 6.x which seems to cause no
issue.