### PR TITLE
Fix migrations when running from scratch

### DIFF
--- a/db/migrate/20170107173635_create_versions.rb
+++ b/db/migrate/20170107173635_create_versions.rb
@@ -1,14 +1,6 @@
 # This migration creates the `versions` table, the only schema PT requires.
 # All other migrations PT provides are optional.
-class CreateVersions < ActiveRecord::Migration[5.0]
-  # Class names of MySQL adapters.
-  # - `MysqlAdapter` - Used by gems: `mysql`, `activerecord-jdbcmysql-adapter`.
-  # - `Mysql2Adapter` - Used by `mysql2` gem.
-  MYSQL_ADAPTERS = [
-    "ActiveRecord::ConnectionAdapters::MysqlAdapter",
-    "ActiveRecord::ConnectionAdapters::Mysql2Adapter"
-  ].freeze
-
+class CreateVersions < ActiveRecord::Migration[6.1]
   # The largest text column available in all supported RDBMS is
   # 1024^3 - 1 bytes, roughly one gibibyte.  We specify a size
   # so that MySQL will use `longtext` instead of `text`.  Otherwise,
@@ -16,9 +8,9 @@ class CreateVersions < ActiveRecord::Migration[5.0]
   TEXT_BYTES = 1_073_741_823
 
   def change
-    create_table :versions, versions_table_options do |t|
-      t.string :item_type, item_type_options
-      t.integer :item_id, null: false
+    create_table :versions do |t|
+      t.string :item_type, null: false
+      t.bigint :item_id, null: false
       t.string :event, null: false
       t.string :whodunnit
       t.text :object, limit: TEXT_BYTES
@@ -32,49 +24,12 @@ class CreateVersions < ActiveRecord::Migration[5.0]
       # the `created_at` column.
       # (https://dev.mysql.com/doc/refman/5.6/en/fractional-seconds.html)
       #
-      # MySQL users should also upgrade to rails 4.2, which is the first
+      # MySQL users should also upgrade to at least rails 4.2, which is the first
       # version of ActiveRecord with support for fractional seconds in MySQL.
       # (https://github.com/rails/rails/pull/14359)
       #
       t.datetime :created_at
     end
-    add_index :versions, [:item_type, :item_id]
-  end
-
-  private
-
-  # MySQL 5.6 utf8mb4 limit is 191 chars for keys used in indexes.
-  # See https://github.com/airblade/paper_trail/issues/651
-  def item_type_options
-    opt = {null: false}
-    opt[:limit] = 191 if mysql?
-    opt
-  end
-
-  def mysql?
-    MYSQL_ADAPTERS.include?(connection.class.name)
-  end
-
-  # Even modern versions of MySQL still use `latin1` as the default character
-  # encoding. Many users are not aware of this, and run into trouble when they
-  # try to use PaperTrail in apps that otherwise tend to use UTF-8. Postgres, by
-  # comparison, uses UTF-8 except in the unusual case where the OS is configured
-  # with a custom locale.
-  #
-  # - https://dev.mysql.com/doc/refman/5.7/en/charset-applications.html
-  # - http://www.postgresql.org/docs/9.4/static/multibyte.html
-  #
-  # Furthermore, MySQL's original implementation of UTF-8 was flawed, and had
-  # to be fixed later by introducing a new charset, `utf8mb4`.
-  #
-  # - https://mathiasbynens.be/notes/mysql-utf8mb4
-  # - https://dev.mysql.com/doc/refman/5.5/en/charset-unicode-utf8mb4.html
-  #
-  def versions_table_options
-    if mysql?
-      {options: "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci"}
-    else
-      {}
-    end
+    add_index :versions, %i[item_type item_id]
   end
 end

--- a/db/migrate/20180528083426_add_last_modified_user_id_to_versioned_records.rb
+++ b/db/migrate/20180528083426_add_last_modified_user_id_to_versioned_records.rb
@@ -29,7 +29,6 @@ class AddLastModifiedUserIdToVersionedRecords < ActiveRecord::Migration[5.0]
     Page,
     ProgressReport,
     Recommendation,
-    Sdgtarget,
     Taxonomy,
     User,
     UserRole

--- a/db/migrate/20211020033236_rename_last_modified_user_id_to_created_by_id.rb
+++ b/db/migrate/20211020033236_rename_last_modified_user_id_to_created_by_id.rb
@@ -8,7 +8,6 @@ class RenameLastModifiedUserIdToCreatedById < ActiveRecord::Migration[6.1]
     rename_column :pages, :last_modified_user_id, :updated_by_id
     rename_column :progress_reports, :last_modified_user_id, :updated_by_id
     rename_column :recommendations, :last_modified_user_id, :updated_by_id
-    rename_column :sdgtargets, :last_modified_user_id, :updated_by_id
     rename_column :taxonomies, :last_modified_user_id, :updated_by_id
     rename_column :user_roles, :last_modified_user_id, :updated_by_id
     rename_column :users, :last_modified_user_id, :updated_by_id

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,6 +11,7 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2021_10_28_085549) do
+
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -43,7 +44,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.index ["updated_by_id"], name: "index_actors_on_updated_by_id"
   end
 
-  create_table "bookmarks", force: :cascade do |t|
+  create_table "bookmarks", id: :serial, force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "title", null: false
     t.json "view", null: false
@@ -54,7 +55,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.index ["user_id"], name: "index_bookmarks_on_user_id"
   end
 
-  create_table "categories", force: :cascade do |t|
+  create_table "categories", id: :serial, force: :cascade do |t|
     t.text "title"
     t.string "short_title"
     t.text "description"
@@ -75,7 +76,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.index ["taxonomy_id"], name: "index_categories_on_taxonomy_id"
   end
 
-  create_table "due_dates", force: :cascade do |t|
+  create_table "due_dates", id: :serial, force: :cascade do |t|
     t.integer "indicator_id"
     t.date "due_date"
     t.datetime "created_at", null: false
@@ -87,7 +88,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.index ["indicator_id"], name: "index_due_dates_on_indicator_id"
   end
 
-  create_table "framework_frameworks", force: :cascade do |t|
+  create_table "framework_frameworks", id: :serial, force: :cascade do |t|
     t.integer "framework_id"
     t.integer "other_framework_id"
     t.datetime "created_at", null: false
@@ -95,7 +96,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.integer "created_by_id"
   end
 
-  create_table "framework_taxonomies", force: :cascade do |t|
+  create_table "framework_taxonomies", id: :serial, force: :cascade do |t|
     t.integer "framework_id", null: false
     t.integer "taxonomy_id", null: false
     t.datetime "created_at", null: false
@@ -105,7 +106,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.index ["taxonomy_id"], name: "index_framework_taxonomies_on_taxonomy_id"
   end
 
-  create_table "frameworks", force: :cascade do |t|
+  create_table "frameworks", id: :serial, force: :cascade do |t|
     t.text "title", null: false
     t.string "short_title"
     t.text "description"
@@ -117,7 +118,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.integer "created_by_id"
   end
 
-  create_table "indicators", force: :cascade do |t|
+  create_table "indicators", id: :serial, force: :cascade do |t|
     t.text "title", null: false
     t.text "description"
     t.datetime "created_at", null: false
@@ -136,7 +137,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.index ["manager_id"], name: "index_indicators_on_manager_id"
   end
 
-  create_table "measure_categories", force: :cascade do |t|
+  create_table "measure_categories", id: :serial, force: :cascade do |t|
     t.integer "measure_id"
     t.integer "category_id"
     t.datetime "created_at", null: false
@@ -144,7 +145,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.integer "created_by_id"
   end
 
-  create_table "measure_indicators", force: :cascade do |t|
+  create_table "measure_indicators", id: :serial, force: :cascade do |t|
     t.integer "measure_id"
     t.integer "indicator_id"
     t.datetime "created_at", null: false
@@ -160,7 +161,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "measures", force: :cascade do |t|
+  create_table "measures", id: :serial, force: :cascade do |t|
     t.text "title", null: false
     t.text "description"
     t.text "target_date"
@@ -194,7 +195,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.index ["parent_id"], name: "index_measures_on_parent_id"
   end
 
-  create_table "pages", force: :cascade do |t|
+  create_table "pages", id: :serial, force: :cascade do |t|
     t.string "title"
     t.text "content"
     t.string "menu_title"
@@ -207,7 +208,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.index ["draft"], name: "index_pages_on_draft"
   end
 
-  create_table "progress_reports", force: :cascade do |t|
+  create_table "progress_reports", id: :serial, force: :cascade do |t|
     t.integer "indicator_id"
     t.integer "due_date_id"
     t.text "title"
@@ -223,7 +224,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.index ["indicator_id"], name: "index_progress_reports_on_indicator_id"
   end
 
-  create_table "recommendation_categories", force: :cascade do |t|
+  create_table "recommendation_categories", id: :serial, force: :cascade do |t|
     t.integer "recommendation_id"
     t.integer "category_id"
     t.datetime "created_at", null: false
@@ -231,7 +232,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.integer "created_by_id"
   end
 
-  create_table "recommendation_indicators", force: :cascade do |t|
+  create_table "recommendation_indicators", id: :serial, force: :cascade do |t|
     t.integer "recommendation_id"
     t.integer "indicator_id"
     t.datetime "created_at", null: false
@@ -241,7 +242,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.index ["recommendation_id"], name: "index_recommendation_indicators_on_recommendation_id"
   end
 
-  create_table "recommendation_measures", force: :cascade do |t|
+  create_table "recommendation_measures", id: :serial, force: :cascade do |t|
     t.integer "recommendation_id"
     t.integer "measure_id"
     t.datetime "created_at", null: false
@@ -251,7 +252,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.index ["recommendation_id"], name: "index_recommendation_measures_on_recommendation_id"
   end
 
-  create_table "recommendation_recommendations", force: :cascade do |t|
+  create_table "recommendation_recommendations", id: :serial, force: :cascade do |t|
     t.integer "recommendation_id"
     t.integer "other_recommendation_id"
     t.datetime "created_at", null: false
@@ -259,7 +260,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.integer "created_by_id"
   end
 
-  create_table "recommendations", force: :cascade do |t|
+  create_table "recommendations", id: :serial, force: :cascade do |t|
     t.text "title", null: false
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -275,7 +276,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.index ["framework_id"], name: "index_recommendations_on_framework_id"
   end
 
-  create_table "roles", force: :cascade do |t|
+  create_table "roles", id: :serial, force: :cascade do |t|
     t.string "name", null: false
     t.string "friendly_name", null: false
     t.datetime "created_at", null: false
@@ -283,7 +284,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.integer "created_by_id"
   end
 
-  create_table "taxonomies", force: :cascade do |t|
+  create_table "taxonomies", id: :serial, force: :cascade do |t|
     t.text "title", null: false
     t.boolean "tags_measures"
     t.datetime "created_at", null: false
@@ -303,7 +304,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.index ["framework_id"], name: "index_taxonomies_on_framework_id"
   end
 
-  create_table "user_categories", force: :cascade do |t|
+  create_table "user_categories", id: :serial, force: :cascade do |t|
     t.integer "user_id"
     t.integer "category_id"
     t.datetime "created_at", null: false
@@ -311,7 +312,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.integer "created_by_id"
   end
 
-  create_table "user_roles", force: :cascade do |t|
+  create_table "user_roles", id: :serial, force: :cascade do |t|
     t.integer "user_id", null: false
     t.integer "role_id", null: false
     t.datetime "created_at", null: false
@@ -322,7 +323,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.index ["user_id"], name: "index_user_roles_on_user_id"
   end
 
-  create_table "users", force: :cascade do |t|
+  create_table "users", id: :serial, force: :cascade do |t|
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "reset_password_token"
@@ -348,7 +349,7 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
 
   create_table "versions", force: :cascade do |t|
     t.string "item_type", null: false
-    t.integer "item_id", null: false
+    t.bigint "item_id", null: false
     t.string "event", null: false
     t.string "whodunnit"
     t.text "object"


### PR DESCRIPTION
When trying to run `db:migrate` from scratch, it doesn't work.

- Re-generate versions table migration
- Remove mentions of removed sdgtargets table

Closes #51 