### PR TITLE
Update `pages` table and rules

### DIFF
--- a/app/policies/page_policy.rb
+++ b/app/policies/page_policy.rb
@@ -1,26 +1,6 @@
 class PagePolicy < ApplicationPolicy
-  def index?
-    @user.roles.any?
-  end
-
-  def show?
-    @user.roles.any?
-  end
-
-  def create?
-    @user.role?("admin")
-  end
-
   def edit?
     false
-  end
-
-  def update?
-    @user.role?("admin")
-  end
-
-  def destroy?
-    @user.role?("admin")
   end
 
   def permitted_attributes

--- a/db/migrate/20211101083817_add_private_to_pages.rb
+++ b/db/migrate/20211101083817_add_private_to_pages.rb
@@ -1,0 +1,7 @@
+class AddPrivateToPages < ActiveRecord::Migration[6.1]
+  def change
+    change_table :pages do |t|
+      t.boolean :private, default: true, index: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_10_28_085549) do
+ActiveRecord::Schema.define(version: 2021_11_01_083817) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -205,7 +205,9 @@ ActiveRecord::Schema.define(version: 2021_10_28_085549) do
     t.integer "order"
     t.integer "updated_by_id"
     t.integer "created_by_id"
+    t.boolean "private", default: true
     t.index ["draft"], name: "index_pages_on_draft"
+    t.index ["private"], name: "index_pages_on_private"
   end
 
   create_table "progress_reports", id: :serial, force: :cascade do |t|

--- a/spec/controllers/pages_controller_spec.rb
+++ b/spec/controllers/pages_controller_spec.rb
@@ -45,10 +45,19 @@ RSpec.describe PagesController, type: :controller do
 
     context "when signed in" do
       context "as analyst" do
-        subject { get :show, params: {id: draft_page}, format: :json }
-        before { sign_in FactoryBot.create(:user, :analyst) }
+        context "will show page" do
+          subject { get :show, params: {id: page}, format: :json }
+          before { sign_in FactoryBot.create(:user, :analyst) }
 
-        it { expect(subject).to be_not_found }
+          it { expect(subject).to be_ok }
+        end
+
+        context "will not show draft page" do
+          subject { get :show, params: {id: draft_page}, format: :json }
+          before { sign_in FactoryBot.create(:user, :analyst) }
+
+          it { expect(subject).to be_not_found }
+        end
       end
     end
   end
@@ -62,9 +71,9 @@ RSpec.describe PagesController, type: :controller do
     end
 
     context "when signed in" do
-      let(:guest) { FactoryBot.create(:user) }
-      let(:user) { FactoryBot.create(:user, :manager) }
       let(:admin) { FactoryBot.create(:user, :admin) }
+      let(:guest) { FactoryBot.create(:user) }
+      let(:manager) { FactoryBot.create(:user, :manager) }
       let(:taxonomy) { FactoryBot.create(:taxonomy) }
 
       subject do
@@ -84,9 +93,9 @@ RSpec.describe PagesController, type: :controller do
         expect(subject).to be_forbidden
       end
 
-      it "will not allow a manager to create a page" do
-        sign_in user
-        expect(subject).to be_forbidden
+      it "will allow a manager to create a page" do
+        sign_in manager
+        expect(subject).to be_created
       end
 
       it "will not allow an admin to create a page" do
@@ -125,18 +134,18 @@ RSpec.describe PagesController, type: :controller do
     end
 
     context "when user signed in" do
-      let(:guest) { FactoryBot.create(:user) }
-      let(:user) { FactoryBot.create(:user, :manager) }
       let(:admin) { FactoryBot.create(:user, :admin) }
+      let(:guest) { FactoryBot.create(:user) }
+      let(:manager) { FactoryBot.create(:user, :manager) }
 
       it "will not allow a guest to update a page" do
         sign_in guest
         expect(subject).to be_forbidden
       end
 
-      it "will not allow a manager to update a page" do
-        sign_in user
-        expect(subject).to be_forbidden
+      it "will allow a manager to update a page" do
+        sign_in manager
+        expect(subject).to be_ok
       end
 
       it "will allow an admin to update a page" do
@@ -175,7 +184,7 @@ RSpec.describe PagesController, type: :controller do
 
       it "will return the latest updated_by", versioning: true do
         expect(PaperTrail).to be_enabled
-        page.versions.first.update_column(:whodunnit, user.id)
+        page.versions.first.update_column(:whodunnit, manager.id)
         sign_in admin
         json = JSON.parse(subject.body)
         expect(json["data"]["attributes"]["updated_by_id"].to_i).to eq(admin.id)
@@ -194,18 +203,18 @@ RSpec.describe PagesController, type: :controller do
     end
 
     context "when user signed in" do
-      let(:guest) { FactoryBot.create(:user) }
-      let(:user) { FactoryBot.create(:user, :manager) }
       let(:admin) { FactoryBot.create(:user, :admin) }
+      let(:guest) { FactoryBot.create(:user) }
+      let(:manager) { FactoryBot.create(:user, :manager) }
 
       it "will not allow a guest to delete a page" do
         sign_in guest
         expect(subject).to be_forbidden
       end
 
-      it "will not allow a manager to delete a page" do
-        sign_in user
-        expect(subject).to be_forbidden
+      it "will allow a manager to delete a page" do
+        sign_in manager
+        expect(subject).to be_no_content
       end
 
       it "will allow an admin to delete a page" do


### PR DESCRIPTION
Implements #38 

We want to add `private` to the `pages` table, and update the permissions:

##### Permissions by role

- public: none
- registered, no role: none 
- analyst: R (where draft = false, ADDED 19/10/)
- manager: CRUD
- admin: CRUD