### PR TITLE
Depluralise first table name in many to many relationships

### DIFF
--- a/app/models/actor_measure.rb
+++ b/app/models/actor_measure.rb
@@ -1,6 +1,4 @@
 class ActorMeasure < VersionedRecord
-  self.table_name = :actors_measures
-
   belongs_to :actor, required: true
   belongs_to :measure, required: true
 

--- a/app/models/actortype_taxonomy.rb
+++ b/app/models/actortype_taxonomy.rb
@@ -1,6 +1,4 @@
 class ActortypeTaxonomy < ApplicationRecord
-  self.table_name = :actortypes_taxonomies
-
   belongs_to :actortype
   belongs_to :taxonomy
 end

--- a/app/models/measure_actor.rb
+++ b/app/models/measure_actor.rb
@@ -1,6 +1,4 @@
 class MeasureActor < VersionedRecord
-  self.table_name = :measures_actors
-
   belongs_to :actor, required: true
   belongs_to :measure, required: true
 

--- a/app/models/measuretype_taxonomy.rb
+++ b/app/models/measuretype_taxonomy.rb
@@ -1,6 +1,4 @@
 class MeasuretypeTaxonomy < ApplicationRecord
-  self.table_name = :measuretypes_taxonomies
-
   belongs_to :measuretype
   belongs_to :taxonomy
 end

--- a/db/migrate/20211103091955_depluralise_first_many_to_many_tables.rb
+++ b/db/migrate/20211103091955_depluralise_first_many_to_many_tables.rb
@@ -1,0 +1,8 @@
+class DepluraliseFirstManyToManyTables < ActiveRecord::Migration[6.1]
+  def change
+    rename_table :actors_measures, :actor_measures
+    rename_table :measures_actors, :measure_actors
+    rename_table :actortypes_taxonomies, :actortype_taxonomies
+    rename_table :measuretypes_taxonomies, :measuretype_taxonomies
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,26 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_03_076221) do
+ActiveRecord::Schema.define(version: 2021_11_03_091955) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "actor_measures", force: :cascade do |t|
+    t.bigint "actor_id", null: false
+    t.bigint "measure_id", null: false
+    t.date "date_start"
+    t.date "date_end"
+    t.decimal "value"
+    t.bigint "created_by_id", null: false
+    t.bigint "updated_by_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["actor_id"], name: "index_actor_measures_on_actor_id"
+    t.index ["created_by_id"], name: "index_actor_measures_on_created_by_id"
+    t.index ["measure_id"], name: "index_actor_measures_on_measure_id"
+    t.index ["updated_by_id"], name: "index_actor_measures_on_updated_by_id"
+  end
 
   create_table "actors", force: :cascade do |t|
     t.bigint "actortype_id", null: false
@@ -35,20 +51,13 @@ ActiveRecord::Schema.define(version: 2021_11_03_076221) do
     t.index ["updated_by_id"], name: "index_actors_on_updated_by_id"
   end
 
-  create_table "actors_measures", force: :cascade do |t|
-    t.bigint "actor_id", null: false
-    t.bigint "measure_id", null: false
-    t.date "date_start"
-    t.date "date_end"
-    t.decimal "value"
-    t.bigint "created_by_id", null: false
-    t.bigint "updated_by_id", null: false
+  create_table "actortype_taxonomies", force: :cascade do |t|
+    t.bigint "actortype_id", null: false
+    t.bigint "taxonomy_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["actor_id"], name: "index_actors_measures_on_actor_id"
-    t.index ["created_by_id"], name: "index_actors_measures_on_created_by_id"
-    t.index ["measure_id"], name: "index_actors_measures_on_measure_id"
-    t.index ["updated_by_id"], name: "index_actors_measures_on_updated_by_id"
+    t.index ["actortype_id"], name: "index_actortype_taxonomies_on_actortype_id"
+    t.index ["taxonomy_id"], name: "index_actortype_taxonomies_on_taxonomy_id"
   end
 
   create_table "actortypes", force: :cascade do |t|
@@ -58,15 +67,6 @@ ActiveRecord::Schema.define(version: 2021_11_03_076221) do
     t.boolean "is_target", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-  end
-
-  create_table "actortypes_taxonomies", force: :cascade do |t|
-    t.bigint "actortype_id", null: false
-    t.bigint "taxonomy_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["actortype_id"], name: "index_actortypes_taxonomies_on_actortype_id"
-    t.index ["taxonomy_id"], name: "index_actortypes_taxonomies_on_taxonomy_id"
   end
 
   create_table "bookmarks", id: :serial, force: :cascade do |t|
@@ -162,6 +162,22 @@ ActiveRecord::Schema.define(version: 2021_11_03_076221) do
     t.index ["manager_id"], name: "index_indicators_on_manager_id"
   end
 
+  create_table "measure_actors", force: :cascade do |t|
+    t.bigint "actor_id", null: false
+    t.bigint "measure_id", null: false
+    t.date "date_start"
+    t.date "date_end"
+    t.decimal "value"
+    t.bigint "created_by_id", null: false
+    t.bigint "updated_by_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["actor_id"], name: "index_measure_actors_on_actor_id"
+    t.index ["created_by_id"], name: "index_measure_actors_on_created_by_id"
+    t.index ["measure_id"], name: "index_measure_actors_on_measure_id"
+    t.index ["updated_by_id"], name: "index_measure_actors_on_updated_by_id"
+  end
+
   create_table "measure_categories", id: :serial, force: :cascade do |t|
     t.integer "measure_id"
     t.integer "category_id"
@@ -212,20 +228,13 @@ ActiveRecord::Schema.define(version: 2021_11_03_076221) do
     t.index ["parent_id"], name: "index_measures_on_parent_id"
   end
 
-  create_table "measures_actors", force: :cascade do |t|
-    t.bigint "actor_id", null: false
-    t.bigint "measure_id", null: false
-    t.date "date_start"
-    t.date "date_end"
-    t.decimal "value"
-    t.bigint "created_by_id", null: false
-    t.bigint "updated_by_id", null: false
+  create_table "measuretype_taxonomies", force: :cascade do |t|
+    t.bigint "measuretype_id", null: false
+    t.bigint "taxonomy_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["actor_id"], name: "index_measures_actors_on_actor_id"
-    t.index ["created_by_id"], name: "index_measures_actors_on_created_by_id"
-    t.index ["measure_id"], name: "index_measures_actors_on_measure_id"
-    t.index ["updated_by_id"], name: "index_measures_actors_on_updated_by_id"
+    t.index ["measuretype_id"], name: "index_measuretype_taxonomies_on_measuretype_id"
+    t.index ["taxonomy_id"], name: "index_measuretype_taxonomies_on_taxonomy_id"
   end
 
   create_table "measuretypes", force: :cascade do |t|
@@ -234,15 +243,6 @@ ActiveRecord::Schema.define(version: 2021_11_03_076221) do
     t.boolean "has_parent", default: true
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-  end
-
-  create_table "measuretypes_taxonomies", force: :cascade do |t|
-    t.bigint "measuretype_id", null: false
-    t.bigint "taxonomy_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["measuretype_id"], name: "index_measuretypes_taxonomies_on_measuretype_id"
-    t.index ["taxonomy_id"], name: "index_measuretypes_taxonomies_on_taxonomy_id"
   end
 
   create_table "pages", id: :serial, force: :cascade do |t|
@@ -409,25 +409,25 @@ ActiveRecord::Schema.define(version: 2021_11_03_076221) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  add_foreign_key "actor_measures", "actors"
+  add_foreign_key "actor_measures", "measures"
+  add_foreign_key "actor_measures", "users", column: "created_by_id"
+  add_foreign_key "actor_measures", "users", column: "updated_by_id"
   add_foreign_key "actors", "actortypes"
-  add_foreign_key "actors_measures", "actors"
-  add_foreign_key "actors_measures", "measures"
-  add_foreign_key "actors_measures", "users", column: "created_by_id"
-  add_foreign_key "actors_measures", "users", column: "updated_by_id"
-  add_foreign_key "actortypes_taxonomies", "actortypes"
-  add_foreign_key "actortypes_taxonomies", "taxonomies"
+  add_foreign_key "actortype_taxonomies", "actortypes"
+  add_foreign_key "actortype_taxonomies", "taxonomies"
   add_foreign_key "framework_frameworks", "frameworks"
   add_foreign_key "framework_frameworks", "frameworks", column: "other_framework_id"
   add_foreign_key "framework_taxonomies", "frameworks"
   add_foreign_key "framework_taxonomies", "taxonomies"
+  add_foreign_key "measure_actors", "actors"
+  add_foreign_key "measure_actors", "measures"
+  add_foreign_key "measure_actors", "users", column: "created_by_id"
+  add_foreign_key "measure_actors", "users", column: "updated_by_id"
   add_foreign_key "measures", "measures", column: "parent_id"
   add_foreign_key "measures", "measuretypes"
-  add_foreign_key "measures_actors", "actors"
-  add_foreign_key "measures_actors", "measures"
-  add_foreign_key "measures_actors", "users", column: "created_by_id"
-  add_foreign_key "measures_actors", "users", column: "updated_by_id"
-  add_foreign_key "measuretypes_taxonomies", "measuretypes"
-  add_foreign_key "measuretypes_taxonomies", "taxonomies"
+  add_foreign_key "measuretype_taxonomies", "measuretypes"
+  add_foreign_key "measuretype_taxonomies", "taxonomies"
   add_foreign_key "recommendation_indicators", "indicators"
   add_foreign_key "recommendation_indicators", "recommendations"
   add_foreign_key "recommendation_recommendations", "recommendations"


### PR DESCRIPTION
Implements #63

Rails convention is to name many to many tables with both sides
having a plural name, however for this project we don't want to
do that.

- renames `actors_measures` to `actor_measures`
- renames `measures_actors` to `measure_actors`
- renames `actortypes_taxonomies` to `actortype_taxonomies`
- renames `measuretypes_taxonomies` to `measuretype_taxonomies`

Closes #20
Closes #21 
Closes #23 
Closes #26