### PR TITLE
Only authorise `base_object` when it exists

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -27,7 +27,7 @@ class ApplicationController < ActionController::Base
   protected
 
   def authorize_base_object!
-    authorize base_object
+    authorize(base_object) if defined?(base_object)
   end
 
   def serialize(target, serializer:)

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -15,9 +15,12 @@ class Seeds
   private
 
   def run_env_seeds!
-    send("#{Rails.env}_seeds!")
-  rescue NameError
-    log "Seeds for #{Rails.env} not defined, skipping.", level: :warn
+    seeder = "#{Rails.env}_seeds!"
+    if defined?(seeder)
+      send(seeder)
+    else
+      log "Seeds for #{Rails.env} not defined, skipping.", level: :warn
+    end
   end
 
   def base_seeds!
@@ -137,6 +140,7 @@ class Seeds
 
   def development_seeds!
     return unless User.count.zero?
+
     FactoryBot.create(:user).tap do |user|
       log "Seed user created: Log in with #{user.email} and password #{user.password}"
       user.roles << Role.find_by(name: "manager")


### PR DESCRIPTION
We have an issue where Devise's magic controllers can't run the
`authorize_base_object!` method because they don't have a `base_object`
defined.

The best way to fix this seems to be to only try to run the `authorize`
functionality when `base_object` exists for a controller.

Fixes #66 

While testing this, I've also made an update to `db/seeds.rb` which is
helpful because errors that were nothing to do with the env seeds
method were being suppressed by `rescue NameError`. Instead, we now
check whether the method is defined before calling it so that any errors
can bubble through and we can fix them.