### PR TITLE
Update `measure_categories` rules

### DIFF
--- a/app/models/measure_category.rb
+++ b/app/models/measure_category.rb
@@ -7,4 +7,14 @@ class MeasureCategory < ApplicationRecord
   validates :category_id, uniqueness: {scope: :measure_id}
   validates :measure_id, presence: true
   validates :category_id, presence: true
+
+  validate :category_taxonomy_enabled_for_measuretype
+
+  private
+
+  def category_taxonomy_enabled_for_measuretype
+    unless category&.taxonomy&.measuretype_ids&.include?(measure&.measuretype_id)
+      errors.add(:measure_id, "must have the category's taxonomy enabled for its measuretype")
+    end
+  end
 end

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -7,6 +7,9 @@ class Taxonomy < VersionedRecord
   has_many :frameworks, through: :framework_taxonomies
   belongs_to :framework, optional: true
 
+  has_many :measuretype_taxonomies
+  has_many :measuretypes, through: :measuretype_taxonomies
+
   validates :title, presence: true
 
   validates :allow_multiple, inclusion: [true, false]

--- a/app/policies/measure_category_policy.rb
+++ b/app/policies/measure_category_policy.rb
@@ -2,22 +2,29 @@
 
 class MeasureCategoryPolicy < ApplicationPolicy
   def permitted_attributes
-    [:measure_id,
+    [
       :category_id,
-      measure_attributes: [:title, :description, :target_date, :draft],
-      category_attributes: [:id, :title, :short_title, :description, :url,
-        :taxonomy_id,
+      :measure_id,
+      measure_attributes: [
+        :description,
         :draft,
-        :manager_id]]
+        :target_date,
+        :title
+      ],
+      category_attributes: [
+        :description,
+        :draft,
+        :id,
+        :manager_id,
+        :short_title,
+        :taxonomy_id,
+        :title,
+        :url
+      ]
+    ]
   end
 
   def update?
     false
-  end
-
-  class Scope < Scope
-    def resolve
-      scope.all
-    end
   end
 end

--- a/spec/controllers/measure_categories_controller_spec.rb
+++ b/spec/controllers/measure_categories_controller_spec.rb
@@ -2,6 +2,12 @@ require "rails_helper"
 require "json"
 
 RSpec.describe MeasureCategoriesController, type: :controller do
+  let(:category) { FactoryBot.create(:category) }
+  let(:measure) { FactoryBot.create(:measure) }
+  let!(:measuretype_taxonomy) do
+    FactoryBot.create(:measuretype_taxonomy, measuretype: measure.measuretype, taxonomy: category.taxonomy)
+  end
+
   describe "Get index" do
     subject { get :index, format: :json }
 
@@ -11,7 +17,7 @@ RSpec.describe MeasureCategoriesController, type: :controller do
   end
 
   describe "Get show" do
-    let(:measure_category) { FactoryBot.create(:measure_category) }
+    let(:measure_category) { FactoryBot.create(:measure_category, category: category, measure: measure) }
     subject { get :show, params: {id: measure_category}, format: :json }
 
     context "when not signed in" do
@@ -30,8 +36,6 @@ RSpec.describe MeasureCategoriesController, type: :controller do
     context "when signed in" do
       let(:guest) { FactoryBot.create(:user) }
       let(:user) { FactoryBot.create(:user, :manager) }
-      let(:measure) { FactoryBot.create(:measure) }
-      let(:category) { FactoryBot.create(:category) }
 
       subject do
         post :create,
@@ -63,7 +67,7 @@ RSpec.describe MeasureCategoriesController, type: :controller do
   end
 
   describe "Delete destroy" do
-    let(:measure_category) { FactoryBot.create(:measure_category) }
+    let(:measure_category) { FactoryBot.create(:measure_category, category: category, measure: measure) }
     subject { delete :destroy, format: :json, params: {id: measure_category} }
 
     context "when not signed in" do

--- a/spec/controllers/measures_controller_spec.rb
+++ b/spec/controllers/measures_controller_spec.rb
@@ -55,6 +55,9 @@ RSpec.describe MeasuresController, type: :controller do
       context "when signed in" do
         it "filters from category" do
           sign_in manager
+          FactoryBot.create(:measuretype_taxonomy,
+            measuretype: measure_different_category.measuretype,
+            taxonomy: category.taxonomy)
           measure_different_category.categories << category
           subject = get :index, params: {category_id: category.id}, format: :json
           json = JSON.parse(subject.body)

--- a/spec/models/measure_category_spec.rb
+++ b/spec/models/measure_category_spec.rb
@@ -6,4 +6,20 @@ RSpec.describe MeasureCategory, type: :model do
   it { is_expected.to validate_uniqueness_of(:category_id).scoped_to(:measure_id) }
   it { is_expected.to validate_presence_of :category_id }
   it { is_expected.to validate_presence_of :measure_id }
+
+  let(:category) { FactoryBot.create(:category) }
+  let(:measure) { FactoryBot.create(:measure) }
+
+  it "errors when the category's taxonomy is not enabled for its measuretype" do
+    measure_category = described_class.create(category: category, measure: measure)
+    expect(measure_category).to be_invalid
+    expect(measure_category.errors[:measure_id]).to include("must have the category's taxonomy enabled for its measuretype")
+  end
+
+  it "works when the category's taxonomy is enabled for its measuretype" do
+    FactoryBot.create(:measuretype_taxonomy, measuretype: measure.measuretype, taxonomy: category.taxonomy)
+
+    measure_category = described_class.create(category: category, measure: measure)
+    expect(measure_category).to be_valid
+  end
 end


### PR DESCRIPTION
Fixes #27

We want to add a rule to make sure measure categories can only be
created for measures and categories that are compatible with each other
through the category's taxonomy's measuretype, and the measure's
measuretype matching up.

##### Permissions by role

- public: none
- registered, no role: none
- analyst: R
- manager: CRD
- admin: CRD

##### Rules

- only for measures where category's taxonomy is enabled for measuretype (in measuretype_taxonomies table, `category.taxonomy.measuretype = measure.measuretype`)