### PR TITLE
Create `actor_categories` schema and API

### DIFF
--- a/app/controllers/actor_categories_controller.rb
+++ b/app/controllers/actor_categories_controller.rb
@@ -1,0 +1,50 @@
+class ActorCategoriesController < ApplicationController
+  before_action :set_and_authorize_actor_category, only: [:show, :destroy]
+
+  # GET /actor_categories
+  def index
+    @actor_categories = policy_scope(base_object).order(created_at: :desc).page(params[:page])
+    authorize @actor_categories
+
+    render json: serialize(@actor_categories)
+  end
+
+  # GET /actor_categories/1
+  def show
+    render json: serialize(@actor_category)
+  end
+
+  # POST /actor_categories
+  def create
+    @actor_category = ActorCategory.new
+    @actor_category.assign_attributes(permitted_attributes(@actor_category))
+    authorize @actor_category
+
+    if @actor_category.save
+      render json: serialize(@actor_category), status: :created, location: @actor_category
+    else
+      render json: @actor_category.errors, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /actor_categories/1
+  def destroy
+    @actor_category.destroy
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_and_authorize_actor_category
+    @actor_category = policy_scope(base_object).find(params[:id])
+    authorize @actor_category
+  end
+
+  def base_object
+    ActorCategory
+  end
+
+  def serialize(target, serializer: ActorCategorySerializer)
+    super
+  end
+end

--- a/app/models/actor_category.rb
+++ b/app/models/actor_category.rb
@@ -1,0 +1,19 @@
+class ActorCategory < ApplicationRecord
+  belongs_to :actor, required: true
+  belongs_to :category, required: true
+
+  accepts_nested_attributes_for :actor
+  accepts_nested_attributes_for :category
+
+  validates :actor_id, presence: true
+  validates :category_id, presence: true, uniqueness: {scope: :actor_id}
+  validate :category_taxonomy_enabled_for_actortype
+
+  private
+
+  def category_taxonomy_enabled_for_actortype
+    unless category&.taxonomy&.actortype_ids&.include?(actor&.actortype_id)
+      errors.add(:category, "must have its taxonomy enabled for actor's actortype")
+    end
+  end
+end

--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -1,4 +1,7 @@
 class Taxonomy < VersionedRecord
+  has_many :actortype_taxonomies
+  has_many :actortypes, through: :actortype_taxonomies
+
   has_many :categories
   belongs_to :taxonomy, class_name: "Taxonomy", foreign_key: :parent_id, optional: true
   has_many :taxonomies, class_name: "Taxonomy", foreign_key: :parent_id

--- a/app/policies/actor_category_policy.rb
+++ b/app/policies/actor_category_policy.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+class ActorCategoryPolicy < ApplicationPolicy
+  def permitted_attributes
+    [
+      :category_id,
+      :actor_id,
+      actor_attributes: [
+        :activity_summary,
+        :actortype_id,
+        :code,
+        :description,
+        :draft,
+        :gdp,
+        :population,
+        :private,
+        :title,
+        :url
+      ],
+      category_attributes: [
+        :description,
+        :draft,
+        :id,
+        :manager_id,
+        :short_title,
+        :taxonomy_id,
+        :title,
+        :url
+      ]
+    ]
+  end
+
+  def update?
+    false
+  end
+end

--- a/app/serializers/actor_category_serializer.rb
+++ b/app/serializers/actor_category_serializer.rb
@@ -1,0 +1,7 @@
+class ActorCategorySerializer
+  include FastApplicationSerializer
+
+  attributes :actor_id, :category_id
+
+  set_type :actor_categories
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,7 +8,7 @@ Rails.application.routes.draw do
   end
   get "static_pages/home"
 
-  resources :actor_categories, except: [:edit, :update]
+  resources :actor_categories, only: [:index, :show, :create, :destroy]
   resources :actor_measures, only: [:index, :show]
   resources :actors
   resources :actortype_taxonomies, only: [:index, :show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,7 @@ Rails.application.routes.draw do
   end
   get "static_pages/home"
 
+  resources :actor_categories, except: [:edit, :update]
   resources :actor_measures, only: [:index, :show]
   resources :actors
   resources :actortype_taxonomies, only: [:index, :show]

--- a/db/migrate/20211108064922_create_actor_categories.rb
+++ b/db/migrate/20211108064922_create_actor_categories.rb
@@ -1,0 +1,12 @@
+class CreateActorCategories < ActiveRecord::Migration[6.1]
+  def change
+    create_table :actor_categories do |t|
+      t.belongs_to :actor, foreign_key: true, index: true, null: false
+      t.belongs_to :category, foreign_key: true, index: true, null: false
+
+      t.belongs_to :created_by, foreign_key: {to_table: "users"}, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,21 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_03_091955) do
+ActiveRecord::Schema.define(version: 2021_11_08_064922) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "actor_categories", force: :cascade do |t|
+    t.bigint "actor_id", null: false
+    t.bigint "category_id", null: false
+    t.bigint "created_by_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["actor_id"], name: "index_actor_categories_on_actor_id"
+    t.index ["category_id"], name: "index_actor_categories_on_category_id"
+    t.index ["created_by_id"], name: "index_actor_categories_on_created_by_id"
+  end
 
   create_table "actor_measures", force: :cascade do |t|
     t.bigint "actor_id", null: false
@@ -409,6 +420,9 @@ ActiveRecord::Schema.define(version: 2021_11_03_091955) do
     t.index ["item_type", "item_id"], name: "index_versions_on_item_type_and_item_id"
   end
 
+  add_foreign_key "actor_categories", "actors"
+  add_foreign_key "actor_categories", "categories"
+  add_foreign_key "actor_categories", "users", column: "created_by_id"
   add_foreign_key "actor_measures", "actors"
   add_foreign_key "actor_measures", "measures"
   add_foreign_key "actor_measures", "users", column: "created_by_id"

--- a/spec/controllers/actor_categories_controller_spec.rb
+++ b/spec/controllers/actor_categories_controller_spec.rb
@@ -1,0 +1,94 @@
+require "rails_helper"
+require "json"
+
+RSpec.describe ActorCategoriesController, type: :controller do
+  let(:category) { FactoryBot.create(:category) }
+  let(:actor) { FactoryBot.create(:actor) }
+  let!(:actortype_taxonomy) do
+    FactoryBot.create(:actortype_taxonomy, actortype: actor.actortype, taxonomy: category.taxonomy)
+  end
+
+  describe "Get index" do
+    subject { get :index, format: :json }
+
+    context "when not signed in" do
+      it { expect(subject).to be_forbidden }
+    end
+  end
+
+  describe "Get show" do
+    let(:actor_category) { FactoryBot.create(:actor_category, category: category, actor: actor) }
+    subject { get :show, params: {id: actor_category}, format: :json }
+
+    context "when not signed in" do
+      it { expect(subject).to be_forbidden }
+    end
+  end
+
+  describe "Post create" do
+    context "when not signed in" do
+      it "not allow creating a actor_category" do
+        post :create, format: :json, params: {actor_category: {actor_id: 1, category_id: 1}}
+        expect(response).to be_unauthorized
+      end
+    end
+
+    context "when signed in" do
+      let(:guest) { FactoryBot.create(:user) }
+      let(:user) { FactoryBot.create(:user, :manager) }
+
+      subject do
+        post :create,
+          format: :json,
+          params: {
+            actor_category: {
+              actor_id: actor.id,
+              category_id: category.id
+            }
+          }
+      end
+
+      it "will not allow a guest to create a actor_category" do
+        sign_in guest
+        expect(subject).to be_forbidden
+      end
+
+      it "will allow a manager to create a actor_category" do
+        sign_in user
+        expect(subject).to be_created
+      end
+
+      it "will return an error if params are incorrect" do
+        sign_in user
+        post :create, format: :json, params: {actor_category: {description: "desc only", taxonomy_id: 999}}
+        expect(response).to have_http_status(422)
+      end
+    end
+  end
+
+  describe "Delete destroy" do
+    let(:actor_category) { FactoryBot.create(:actor_category, category: category, actor: actor) }
+    subject { delete :destroy, format: :json, params: {id: actor_category} }
+
+    context "when not signed in" do
+      it "not allow deleting a actor_category" do
+        expect(subject).to be_unauthorized
+      end
+    end
+
+    context "when user signed in" do
+      let(:guest) { FactoryBot.create(:user) }
+      let(:user) { FactoryBot.create(:user, :manager) }
+
+      it "will not allow a guest to delete a actor_category" do
+        sign_in guest
+        expect(subject).to be_forbidden
+      end
+
+      it "will allow a manager to delete a actor_category" do
+        sign_in user
+        expect(subject).to be_no_content
+      end
+    end
+  end
+end

--- a/spec/factories/actor_categories.rb
+++ b/spec/factories/actor_categories.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :actor_category do
+    association :actor
+    association :category
+
+    association :created_by, factory: :user
+  end
+end

--- a/spec/models/actor_category_spec.rb
+++ b/spec/models/actor_category_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+RSpec.describe ActorCategory, type: :model do
+  it { is_expected.to belong_to :actor }
+  it { is_expected.to belong_to :category }
+  it { is_expected.to validate_presence_of :category_id }
+  it { is_expected.to validate_presence_of :actor_id }
+
+  let(:actor) { FactoryBot.create(:actor) }
+  let(:category) { FactoryBot.create(:category) }
+
+  it "errors when the category's taxonomy is not enabled for its actortype" do
+    actor_category = described_class.create(category: category, actor: actor)
+    expect(actor_category).to be_invalid
+    expect(actor_category.errors[:category]).to include("must have its taxonomy enabled for actor's actortype")
+  end
+
+  it "works when the category's taxonomy is enabled for its actortype" do
+    FactoryBot.create(:actortype_taxonomy, actortype: actor.actortype, taxonomy: category.taxonomy)
+
+    actor_category = described_class.create(category: category, actor: actor)
+    expect(actor_category).to be_valid
+  end
+end


### PR DESCRIPTION
Implements #24  

We need a many to many join table describing a relationship between
`actors`, introduced for #18, and `categories`, from impact.

##### Permissions by role

- public: none
- registered, no role: none
- analyst: R
- manager: CRD
- admin: CRD

##### Rules

- Only for actors where `category`'s taxonomy is enabled for `actortype`