### PR TITLE
Define missing actions for `actor_measures` and `measure_actors`

### DIFF
--- a/app/controllers/actor_measures_controller.rb
+++ b/app/controllers/actor_measures_controller.rb
@@ -1,7 +1,8 @@
 class ActorMeasuresController < ApplicationController
+  before_action :set_and_authorize_actor_measure, only: [:show, :update, :destroy]
+
   # GET /actor_measures/:id
   def show
-    @actor_measure = policy_scope(base_object).find(params[:id])
     authorize @actor_measure
     render json: serialize(@actor_measure)
   end
@@ -13,7 +14,39 @@ class ActorMeasuresController < ApplicationController
     render json: serialize(@actor_measures)
   end
 
+  # POST /actor_measures
+  def create
+    @actor_measure = ActorMeasure.new
+    @actor_measure.assign_attributes(permitted_attributes(@actor_measure))
+    authorize @actor_measure
+
+    if @actor_measure.save
+      render json: serialize(@actor_measure), status: :created, location: @actor_measure
+    else
+      render json: @actor_measure.errors, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /actor_measures/1
+  def destroy
+    @actor_measure.destroy
+  end
+
+  # PATCH/PUT /actor_categories/1
+  def update
+    if @actor_measure.update!(permitted_attributes(@actor_measure))
+      set_and_authorize_actor_measure
+      render json: serialize(@actor_measure)
+    end
+  end
+
   private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_and_authorize_actor_measure
+    @actor_measure = policy_scope(base_object).find(params[:id])
+    authorize @actor_measure
+  end
 
   def base_object
     ActorMeasure

--- a/app/controllers/measure_actors_controller.rb
+++ b/app/controllers/measure_actors_controller.rb
@@ -1,4 +1,6 @@
 class MeasureActorsController < ApplicationController
+  before_action :set_and_authorize_measure_actor, only: [:show, :update, :destroy]
+
   # GET /measure_actors/:id
   def show
     @measure_actor = policy_scope(base_object).find(params[:id])
@@ -13,7 +15,39 @@ class MeasureActorsController < ApplicationController
     render json: serialize(@measure_actors)
   end
 
+  # POST /measure_actors
+  def create
+    @measure_actor = MeasureActor.new
+    @measure_actor.assign_attributes(permitted_attributes(@measure_actor))
+    authorize @measure_actor
+
+    if @measure_actor.save
+      render json: serialize(@measure_actor), status: :created, location: @measure_actor
+    else
+      render json: @measure_actor.errors, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /measure_actors/1
+  def destroy
+    @measure_actor.destroy
+  end
+
+  # PATCH/PUT /actor_categories/1
+  def update
+    if @measure_actor.update!(permitted_attributes(@measure_actor))
+      set_and_authorize_measure_actor
+      render json: serialize(@measure_actor)
+    end
+  end
+
   private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_and_authorize_measure_actor
+    @measure_actor = policy_scope(base_object).find(params[:id])
+    authorize @measure_actor
+  end
 
   def base_object
     MeasureActor

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,11 +9,11 @@ Rails.application.routes.draw do
   get "static_pages/home"
 
   resources :actor_categories, only: [:index, :show, :create, :destroy]
-  resources :actor_measures, only: [:index, :show]
+  resources :actor_measures, only: [:index, :show, :create, :update, :destroy]
   resources :actors
   resources :actortype_taxonomies, only: [:index, :show]
   resources :actortypes, only: [:index, :show]
-  resources :measure_actors, only: [:index, :show]
+  resources :measure_actors, only: [:index, :show, :create, :update, :destroy]
   resources :measure_categories
   resources :measure_indicators
   resources :measuretype_taxonomies, only: [:index, :show]

--- a/spec/controllers/actors_measures_controller_spec.rb
+++ b/spec/controllers/actors_measures_controller_spec.rb
@@ -2,6 +2,10 @@ require "rails_helper"
 require "json"
 
 RSpec.describe ActorMeasuresController, type: :controller do
+  let(:analyst) { FactoryBot.create(:user, :analyst) }
+  let(:guest) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, :manager) }
+
   describe "Get index" do
     subject { get :index, format: :json }
 
@@ -55,6 +59,76 @@ RSpec.describe ActorMeasuresController, type: :controller do
         before { sign_in FactoryBot.create(:user, :admin) }
 
         it { expect(subject).to be_ok }
+      end
+    end
+  end
+
+  describe "PUT update" do
+    let(:actor_measure) { FactoryBot.create(:actor_measure) }
+    subject do
+      put :update,
+        format: :json,
+        params: {id: actor_measure,
+                 actor_measure: {value: "4.2"}}
+    end
+
+    context "when not signed in" do
+      it "not allow updating an actor_measure" do
+        expect(subject).to be_unauthorized
+      end
+    end
+
+    context "when user signed in" do
+      it "will not allow a guest to update an actor_measure" do
+        sign_in guest
+        expect(subject).to be_forbidden
+      end
+
+      it "will not allow an analyst to update an actor_measure" do
+        sign_in analyst
+        expect(subject).to be_forbidden
+      end
+
+      it "will allow a manager to update an actor_measure" do
+        sign_in user
+        expect(subject).to be_ok
+        json = JSON.parse(subject.body)
+        expect(json.dig("data", "attributes", "value")).to eq("4.2")
+      end
+
+      it "will return an error if params are incorrect" do
+        sign_in user
+        put :update, format: :json, params: {id: actor_measure,
+                                             actor_measure: {actor_id: 999}}
+        expect(response).to have_http_status(422)
+      end
+    end
+  end
+
+  describe "Delete destroy" do
+    let(:actor_measure) { FactoryBot.create(:actor_measure) }
+    subject { delete :destroy, format: :json, params: {id: actor_measure} }
+
+    context "when not signed in" do
+      it "not allow deleting an actor_measure" do
+        expect(subject).to be_unauthorized
+      end
+    end
+
+    context "when user signed in" do
+      it "will not allow a guest to delete an actor_measure" do
+        sign_in guest
+        expect(subject).to be_forbidden
+      end
+
+      it "will not allow an analyst to delete an actor_measure" do
+        sign_in analyst
+        expect(subject).to be_forbidden
+      end
+
+      it "will allow a manager to delete an actor_measure" do
+        sign_in user
+        expect(subject).to be_no_content
       end
     end
   end

--- a/spec/controllers/measure_actors_controller_spec.rb
+++ b/spec/controllers/measure_actors_controller_spec.rb
@@ -2,6 +2,10 @@ require "rails_helper"
 require "json"
 
 RSpec.describe MeasureActorsController, type: :controller do
+  let(:analyst) { FactoryBot.create(:user, :analyst) }
+  let(:guest) { FactoryBot.create(:user) }
+  let(:user) { FactoryBot.create(:user, :manager) }
+
   describe "Get index" do
     subject { get :index, format: :json }
 
@@ -55,6 +59,76 @@ RSpec.describe MeasureActorsController, type: :controller do
         before { sign_in FactoryBot.create(:user, :admin) }
 
         it { expect(subject).to be_ok }
+      end
+    end
+  end
+
+  describe "PUT update" do
+    let(:measure_actor) { FactoryBot.create(:measure_actor) }
+    subject do
+      put :update,
+        format: :json,
+        params: {id: measure_actor,
+                 measure_actor: {value: "4.2"}}
+    end
+
+    context "when not signed in" do
+      it "not allow updating a measure_actor" do
+        expect(subject).to be_unauthorized
+      end
+    end
+
+    context "when user signed in" do
+      it "will not allow a guest to update a measure_actor" do
+        sign_in guest
+        expect(subject).to be_forbidden
+      end
+
+      it "will not allow an analyst to update an measure_actor" do
+        sign_in analyst
+        expect(subject).to be_forbidden
+      end
+
+      it "will allow a manager to update a measure_actor" do
+        sign_in user
+        expect(subject).to be_ok
+        json = JSON.parse(subject.body)
+        expect(json.dig("data", "attributes", "value")).to eq("4.2")
+      end
+
+      it "will return an error if params are incorrect" do
+        sign_in user
+        put :update, format: :json, params: {id: measure_actor,
+                                             measure_actor: {actor_id: 999}}
+        expect(response).to have_http_status(422)
+      end
+    end
+  end
+
+  describe "Delete destroy" do
+    let(:measure_actor) { FactoryBot.create(:measure_actor) }
+    subject { delete :destroy, format: :json, params: {id: measure_actor} }
+
+    context "when not signed in" do
+      it "not allow deleting a measure_actor" do
+        expect(subject).to be_unauthorized
+      end
+    end
+
+    context "when user signed in" do
+      it "will not allow a guest to delete a measure_actor" do
+        sign_in guest
+        expect(subject).to be_forbidden
+      end
+
+      it "will not allow an analyst to delete a measure_actor" do
+        sign_in analyst
+        expect(subject).to be_forbidden
+      end
+
+      it "will allow a manager to delete a measure_actor" do
+        sign_in user
+        expect(subject).to be_no_content
       end
     end
   end


### PR DESCRIPTION
Fixes #20 
Fixes #21 

We are missing `create`, `destroy`, and `update` routes for `actor_measures`
and `measure_actors`.

This change defines them and their actions and specs.