### PR TITLE
Add `memberships` table and API

### DIFF
--- a/app/controllers/memberships_controller.rb
+++ b/app/controllers/memberships_controller.rb
@@ -1,0 +1,50 @@
+class MembershipsController < ApplicationController
+  before_action :set_and_authorize_membership, only: [:show, :destroy]
+
+  # GET /memberships
+  def index
+    @memberships = policy_scope(base_object).order(created_at: :desc).page(params[:page])
+    authorize @memberships
+
+    render json: serialize(@memberships)
+  end
+
+  # GET /memberships/1
+  def show
+    render json: serialize(@membership)
+  end
+
+  # POST /memberships
+  def create
+    @membership = Membership.new
+    @membership.assign_attributes(permitted_attributes(@membership))
+    authorize @membership
+
+    if @membership.save
+      render json: serialize(@membership), status: :created, location: @membership
+    else
+      render json: @membership.errors, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /memberships/1
+  def destroy
+    @membership.destroy
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_and_authorize_membership
+    @membership = policy_scope(base_object).find(params[:id])
+    authorize @membership
+  end
+
+  def base_object
+    Membership
+  end
+
+  def serialize(target, serializer: MembershipSerializer)
+    super
+  end
+end

--- a/app/models/actor.rb
+++ b/app/models/actor.rb
@@ -1,5 +1,6 @@
 class Actor < VersionedRecord
   belongs_to :actortype, required: true
+  has_many :memberships
 
   validates :code, presence: true
   validates :title, presence: true

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,0 +1,24 @@
+class Membership < ApplicationRecord
+  belongs_to :member, class_name: "Actor", required: true
+  belongs_to :memberof, class_name: "Actor", required: true
+
+  belongs_to :created_by, class_name: "User", required: false
+
+  validate :member_not_memberof
+  validate :memberof_actortype_has_members
+  validate :member_has_no_members_itself
+
+  private
+
+  def member_not_memberof
+    errors.add(:member, "can't be the same as memberof") if member == memberof
+  end
+
+  def memberof_actortype_has_members
+    errors.add(:memberof, "actortype can't have members") unless memberof&.actortype&.has_members
+  end
+
+  def member_has_no_members_itself
+    errors.add(:member, "can't also have members") if member&.actortype&.has_members
+  end
+end

--- a/app/policies/membership_policy.rb
+++ b/app/policies/membership_policy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class MembershipPolicy < ApplicationPolicy
+  def permitted_attributes
+    [
+      :member_id,
+      :memberof_id
+    ]
+  end
+
+  def update?
+    false
+  end
+end

--- a/app/serializers/membership_serializer.rb
+++ b/app/serializers/membership_serializer.rb
@@ -1,0 +1,7 @@
+class MembershipSerializer
+  include FastApplicationSerializer
+
+  attributes :member_id, :memberof_id, :created_by_id
+
+  set_type :memberships
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
   resources :measure_indicators
   resources :measuretype_taxonomies, only: [:index, :show]
   resources :measuretypes, only: [:index, :show]
+  resources :memberships, only: [:index, :show, :create, :destroy]
   resources :recommendation_categories
   resources :user_categories
   resources :recommendation_measures

--- a/db/migrate/20211109073519_create_memberships.rb
+++ b/db/migrate/20211109073519_create_memberships.rb
@@ -1,0 +1,12 @@
+class CreateMemberships < ActiveRecord::Migration[6.1]
+  def change
+    create_table :memberships do |t|
+      t.belongs_to :member, foreign_key: {to_table: "actors"}, index: true, null: false
+      t.belongs_to :memberof, foreign_key: {to_table: "actors"}, index: true, null: false
+
+      t.belongs_to :created_by, foreign_key: {to_table: "users"}, index: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_08_064922) do
+ActiveRecord::Schema.define(version: 2021_11_09_073519) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -256,6 +256,17 @@ ActiveRecord::Schema.define(version: 2021_11_08_064922) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
+  create_table "memberships", force: :cascade do |t|
+    t.bigint "member_id", null: false
+    t.bigint "memberof_id", null: false
+    t.bigint "created_by_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["created_by_id"], name: "index_memberships_on_created_by_id"
+    t.index ["member_id"], name: "index_memberships_on_member_id"
+    t.index ["memberof_id"], name: "index_memberships_on_memberof_id"
+  end
+
   create_table "pages", id: :serial, force: :cascade do |t|
     t.string "title"
     t.text "content"
@@ -442,6 +453,9 @@ ActiveRecord::Schema.define(version: 2021_11_08_064922) do
   add_foreign_key "measures", "measuretypes"
   add_foreign_key "measuretype_taxonomies", "measuretypes"
   add_foreign_key "measuretype_taxonomies", "taxonomies"
+  add_foreign_key "memberships", "actors", column: "member_id"
+  add_foreign_key "memberships", "actors", column: "memberof_id"
+  add_foreign_key "memberships", "users", column: "created_by_id"
   add_foreign_key "recommendation_indicators", "indicators"
   add_foreign_key "recommendation_indicators", "recommendations"
   add_foreign_key "recommendation_recommendations", "recommendations"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_09_073519) do
+ActiveRecord::Schema.define(version: 2021_11_10_070228) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+require "json"
+
+RSpec.describe MembershipsController, type: :controller do
+  let(:member) { FactoryBot.create(:actor) }
+  let(:memberof) { FactoryBot.create(:actor, actortype: FactoryBot.create(:actortype, :with_members)) }
+
+  describe "Get index" do
+    subject { get :index, format: :json }
+
+    context "when not signed in" do
+      it { expect(subject).to be_forbidden }
+    end
+  end
+
+  describe "Get show" do
+    let(:membership) { FactoryBot.create(:membership, member: member, memberof: memberof) }
+    subject { get :show, params: {id: membership}, format: :json }
+
+    context "when not signed in" do
+      it { expect(subject).to be_forbidden }
+    end
+  end
+
+  describe "Post create" do
+    context "when not signed in" do
+      it "not allow creating a membership" do
+        post :create, format: :json, params: {membership: {memberof_id: 1, member_id: 1}}
+        expect(response).to be_unauthorized
+      end
+    end
+
+    context "when signed in" do
+      let(:guest) { FactoryBot.create(:user) }
+      let(:user) { FactoryBot.create(:user, :manager) }
+
+      subject do
+        post :create,
+          format: :json,
+          params: {
+            membership: {
+              memberof_id: memberof.id,
+              member_id: member.id
+            }
+          }
+      end
+
+      it "will not allow a guest to create a membership" do
+        sign_in guest
+        expect(subject).to be_forbidden
+      end
+
+      it "will allow a manager to create a membership" do
+        sign_in user
+        expect(subject).to be_created
+      end
+
+      it "will return an error if params are incorrect" do
+        sign_in user
+        post :create, format: :json, params: {membership: {description: "desc only", taxonomy_id: 999}}
+        expect(response).to have_http_status(422)
+      end
+    end
+  end
+
+  describe "Delete destroy" do
+    let(:membership) { FactoryBot.create(:membership, member: member, memberof: memberof) }
+    subject { delete :destroy, format: :json, params: {id: membership} }
+
+    context "when not signed in" do
+      it "not allow deleting a membership" do
+        expect(subject).to be_unauthorized
+      end
+    end
+
+    context "when user signed in" do
+      let(:guest) { FactoryBot.create(:user) }
+      let(:user) { FactoryBot.create(:user, :manager) }
+
+      it "will not allow a guest to delete a membership" do
+        sign_in guest
+        expect(subject).to be_forbidden
+      end
+
+      it "will allow a manager to delete a membership" do
+        sign_in user
+        expect(subject).to be_no_content
+      end
+    end
+  end
+end

--- a/spec/factories/memberships.rb
+++ b/spec/factories/memberships.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :membership do
+    association :member, factory: :actor
+    association :memberof, factory: :actor
+  end
+end

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.describe Membership, type: :model do
+  it { is_expected.to belong_to :member }
+  it { is_expected.to belong_to :memberof }
+
+  it "errors when the member is the same as the memberof" do
+    member = FactoryBot.create(:actor)
+    membership = described_class.create(member: member, memberof: member)
+    expect(membership).to be_invalid
+    expect(membership.errors[:member]).to include("can't be the same as memberof")
+  end
+
+  it "errors when the memberof's actortype is not has_members" do
+    member = FactoryBot.create(:actor)
+    memberof = FactoryBot.create(:actor, actortype: FactoryBot.create(:actortype, has_members: false))
+    membership = described_class.create(member: member, memberof: memberof)
+    expect(membership).to be_invalid
+    expect(membership.errors[:memberof]).to include("actortype can't have members")
+  end
+
+  it "works when the memberof can have members" do
+    member = FactoryBot.create(:actor)
+    memberof = FactoryBot.create(:actor, actortype: FactoryBot.create(:actortype, :with_members))
+    membership = described_class.create(member: member, memberof: memberof)
+    expect(membership).to be_valid
+  end
+
+  it "errors when the member's actortype is also has_members" do
+    member = FactoryBot.create(:actor, actortype: FactoryBot.create(:actortype, :with_members))
+    memberof = FactoryBot.create(:actor, actortype: FactoryBot.create(:actortype, :with_members))
+    membership = described_class.create(member: member, memberof: memberof)
+    expect(membership).to be_invalid
+    expect(membership.errors[:member]).to include("can't also have members")
+  end
+end


### PR DESCRIPTION
For #19 we want a many to many join table for describing "memberships"
among different actors (a country can be part of a group or region).

##### Permissions by role

- public: none
- registered, no role: none
- analyst: R
- manager: CRD
- admin: CRD

##### Rules

- an actor cannot be an actor of itself (`member_id != memberof_id`)
- an actor can only have members when it is allowed for its type (`memberof.actortype.has_members = true`)
- an actor can only be a member of another actor when it can not also have members (`member.actortype.has_members = false/null`)