### PR TITLE
Update `categories` schema and rules

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -19,23 +19,27 @@ class Category < VersionedRecord
 
   validates :title, presence: true
 
-  validate :sub_relation
+  validate :different_parent
+  validate :no_grandparent
+  validate :consistent_taxonomy
 
-  def sub_relation
-    if parent_id.present?
-      parent_category = Category.find(parent_id)
+  def different_parent
+    if parent_id.present? && parent_id == id
+      errors.add(:parent_id, "Category can't be its own parent")
+    end
+  end
 
-      if !parent_category.parent_id.nil?
-        errors.add(:parent_id, "Parent category is already a sub-category.")
-        return
-      end
+  def no_grandparent
+    if parent_id.present? && category.parent_id.present?
+      errors.add(:parent_id, "Parent category is already a sub-category")
+    end
+  end
 
-      parent_taxonomy_id = Taxonomy.find(taxonomy_id).parent_id
-      parent_category_taxonomy_id = parent_category.taxonomy_id
+  def consistent_taxonomy
+    return if parent_id.blank?
 
-      if parent_category_taxonomy_id != parent_taxonomy_id
-        errors.add(:parent_id, "Taxonomy does not have parent categorys taxonomy as parent.")
-      end
+    if category.taxonomy_id != Taxonomy.find(taxonomy_id).parent_id
+      errors.add(:parent_id, "Taxonomy does not have parent category's taxonomy as parent")
     end
   end
 

--- a/db/migrate/20211110070228_add_private_to_categories.rb
+++ b/db/migrate/20211110070228_add_private_to_categories.rb
@@ -1,0 +1,5 @@
+class AddPrivateToCategories < ActiveRecord::Migration[6.1]
+  def change
+    add_column :categories, :private, :boolean, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_08_212159) do
+ActiveRecord::Schema.define(version: 2021_11_10_070228) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -107,6 +107,7 @@ ActiveRecord::Schema.define(version: 2021_11_08_212159) do
     t.integer "parent_id"
     t.date "date"
     t.integer "created_by_id"
+    t.boolean "private", default: true
     t.index ["draft"], name: "index_categories_on_draft"
     t.index ["manager_id"], name: "index_categories_on_manager_id"
     t.index ["taxonomy_id"], name: "index_categories_on_taxonomy_id"

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -2,26 +2,34 @@ require "rails_helper"
 require "json"
 
 RSpec.describe CategoriesController, type: :controller do
+  let(:analyst) { FactoryBot.create(:user, :analyst) }
+  let(:guest) { FactoryBot.create(:user) }
+  let(:manager) { FactoryBot.create(:user, :manager) }
+  let(:taxonomy) { FactoryBot.create(:taxonomy) }
+
   describe "Get index" do
-    subject { get :index, format: :json }
     let!(:category) { FactoryBot.create(:category) }
     let!(:draft_category) { FactoryBot.create(:category, draft: true) }
+    subject { get :index, format: :json }
 
     context "when not signed in" do
       it { expect(subject).to be_forbidden }
     end
 
     context "when signed in" do
-      let(:guest) { FactoryBot.create(:user) }
-      let(:user) { FactoryBot.create(:user, :manager) }
-
       it "guest will be forbidden" do
         sign_in guest
         expect(subject).to be_forbidden
       end
 
+      it "analyst will see non-draft categories" do
+        sign_in analyst
+        json = JSON.parse(subject.body)
+        expect(json["data"].length).to eq(1)
+      end
+
       it "manager will see draft categories" do
-        sign_in user
+        sign_in manager
         json = JSON.parse(subject.body)
         expect(json["data"].length).to eq(2)
       end
@@ -30,7 +38,6 @@ RSpec.describe CategoriesController, type: :controller do
 
   describe "Get show" do
     let(:category) { FactoryBot.create(:category) }
-    let(:draft_category) { FactoryBot.create(:category, draft: true) }
     subject { get :show, params: {id: category}, format: :json }
 
     context "when not signed in" do
@@ -47,10 +54,6 @@ RSpec.describe CategoriesController, type: :controller do
     end
 
     context "when signed in" do
-      let(:guest) { FactoryBot.create(:user) }
-      let(:user) { FactoryBot.create(:user, :manager) }
-      let(:taxonomy) { FactoryBot.create(:taxonomy) }
-
       subject do
         post :create,
           format: :json,
@@ -71,19 +74,19 @@ RSpec.describe CategoriesController, type: :controller do
       end
 
       it "will allow a manager to create a category" do
-        sign_in user
+        sign_in manager
         expect(subject).to be_created
       end
 
       it "will record what manager created the category", versioning: true do
         expect(PaperTrail).to be_enabled
-        sign_in user
+        sign_in manager
         json = JSON.parse(subject.body)
-        expect(json["data"]["attributes"]["updated_by_id"].to_i).to eq user.id
+        expect(json["data"]["attributes"]["updated_by_id"].to_i).to eq manager.id
       end
 
       it "will return an error if params are incorrect" do
-        sign_in user
+        sign_in manager
         post :create, format: :json, params: {category: {description: "desc only", taxonomy_id: 999}}
         expect(response).to have_http_status(422)
       end
@@ -106,21 +109,23 @@ RSpec.describe CategoriesController, type: :controller do
     end
 
     context "when user signed in" do
-      let(:guest) { FactoryBot.create(:user) }
-      let(:user) { FactoryBot.create(:user, :manager) }
-
       it "will not allow a guest to update a category" do
         sign_in guest
         expect(subject).to be_forbidden
       end
 
+      it "will not allow an analyst to update a category" do
+        sign_in analyst
+        expect(subject).to be_forbidden
+      end
+
       it "will allow a manager to update a category" do
-        sign_in user
+        sign_in manager
         expect(subject).to be_ok
       end
 
       it "will reject and update where the last_updated_at is older than updated_at in the database" do
-        sign_in user
+        sign_in manager
         category_get = get :show, params: {id: category}, format: :json
         json = JSON.parse(category_get.body)
         current_update_at = json["data"]["attributes"]["updated_at"]
@@ -143,21 +148,21 @@ RSpec.describe CategoriesController, type: :controller do
 
       it "will record what manager updated the category", versioning: true do
         expect(PaperTrail).to be_enabled
-        sign_in user
+        sign_in manager
         json = JSON.parse(subject.body)
-        expect(json["data"]["attributes"]["updated_by_id"].to_i).to eq user.id
+        expect(json["data"]["attributes"]["updated_by_id"].to_i).to eq manager.id
       end
 
       it "will return the latest updated_by", versioning: true do
         expect(PaperTrail).to be_enabled
         category.versions.first.update_column(:whodunnit, guest.id)
-        sign_in user
+        sign_in manager
         json = JSON.parse(subject.body)
-        expect(json["data"]["attributes"]["updated_by_id"].to_i).to eq(user.id)
+        expect(json["data"]["attributes"]["updated_by_id"].to_i).to eq(manager.id)
       end
 
       it "will return an error if params are incorrect" do
-        sign_in user
+        sign_in manager
         put :update, format: :json, params: {id: category, category: {taxonomy_id: 999}}
         expect(response).to have_http_status(422)
       end
@@ -175,23 +180,25 @@ RSpec.describe CategoriesController, type: :controller do
     end
 
     context "when user signed in" do
-      let(:guest) { FactoryBot.create(:user) }
-      let(:user) { FactoryBot.create(:user, :manager) }
-
       it "will not allow a guest to delete a category" do
         sign_in guest
         expect(subject).to be_forbidden
       end
 
+      it "will not allow an analyst to delete a category" do
+        sign_in analyst
+        expect(subject).to be_forbidden
+      end
+
       it "will allow a manager to delete a category" do
-        sign_in user
+        sign_in manager
         expect(subject).to be_no_content
       end
 
       it "response with success when versioned", versioning: true do
         expect(PaperTrail).to be_enabled
         category.update_attribute(:title, "something else")
-        sign_in user
+        sign_in manager
         expect(subject.response_code).to eq(204)
       end
     end

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -43,14 +43,23 @@ RSpec.describe Category, type: :model do
       parent_category.save!
 
       sub_category.parent_id = parent_category.id
-      expect { sub_category.save! }.to raise_exception(/Parent category is already a sub-category./)
+      expect(sub_category).to be_invalid
+      expect(sub_category.errors[:parent_id]).to include("Parent category is already a sub-category")
     end
 
     it "Should not update parent_id with incorrect taxonomy relation" do
       category = FactoryBot.create(:category, :parent_category)
       sub_category = FactoryBot.create(:category, :sub_category)
       sub_category.parent_id = category.id
-      expect { sub_category.save! }.to raise_exception(/Validation failed: Parent Taxonomy does not have parent categorys taxonomy as parent./)
+      expect(sub_category).to be_invalid
+      expect(sub_category.errors[:parent_id]).to include("Taxonomy does not have parent category's taxonomy as parent")
+    end
+
+    it "Can't be its own parent" do
+      category = FactoryBot.create(:category)
+      category.update(parent_id: category.id)
+      expect(category).to be_invalid
+      expect(category.errors[:parent_id]).to include("Category can't be its own parent")
     end
   end
 end


### PR DESCRIPTION
Fixes #33 by implementing the required changes:

- Add `private` column, `default: true`.
- Updating specs to cover analyst permissions

##### Permissions by role

- public: none
- registered, no role: none
- analyst: R  (where draft = false, ADDED 19/10/)
- manager: CRUD
- admin: CRUD

##### Rules 

- a category can't be its own parent (`parent_id != id`)
- a category can only be a parent of another category when its taxonomy is also the parent of the other categories taxonomy (`category.parent_category.taxonomy.parent_taxonomy = category.taxonomy`)
- a category that has a parent cannot also be a parent