### PR TITLE
Update taxonomy rules

### DIFF
--- a/app/models/taxonomy.rb
+++ b/app/models/taxonomy.rb
@@ -1,4 +1,4 @@
-class Taxonomy < VersionedRecord
+class Taxonomy < ApplicationRecord
   has_many :actortype_taxonomies
   has_many :actortypes, through: :actortype_taxonomies
 
@@ -17,15 +17,18 @@ class Taxonomy < VersionedRecord
 
   validates :allow_multiple, inclusion: [true, false]
 
+  validate :different_parent
   validate :sub_relation
 
-  def sub_relation
-    if parent_id.present?
-      parent_taxonomy = Taxonomy.find(parent_id)
+  def different_parent
+    if parent_id.present? && parent_id == id
+      errors.add(:parent_id, "Taxonomy can't be its own parent")
+    end
+  end
 
-      if !parent_taxonomy.parent_id.nil?
-        errors.add(:parent_id, "Parent taxonomy is already a sub-taxonomy.")
-      end
+  def sub_relation
+    if parent_id.present? && !taxonomy.parent_id.nil?
+      errors.add(:parent_id, "Parent taxonomy is already a sub-taxonomy")
     end
   end
 end

--- a/app/policies/taxonomy_policy.rb
+++ b/app/policies/taxonomy_policy.rb
@@ -1,35 +1,19 @@
 # frozen_string_literal: true
 
-class TaxonomyPolicy < ApplicationPolicy
+class TaxonomyPolicy < SystemPolicy
   def permitted_attributes
-    [:title,
-      :tags_measures,
+    [
       :allow_multiple,
-      :tags_users,
-      :priority,
-      :is_smart,
+      :framework_id,
       :groups_measures_default,
       :groups_recommendations_default,
-      :parent_id,
       :has_date,
-      :framework_id]
-  end
-
-  def create?
-    false
-  end
-
-  def update?
-    false
-  end
-
-  def destroy?
-    false
-  end
-
-  class Scope < Scope
-    def resolve
-      scope.all
-    end
+      :is_smart,
+      :parent_id,
+      :priority,
+      :tags_measures,
+      :tags_users,
+      :title
+    ]
   end
 end

--- a/spec/controllers/taxonomies_controller_spec.rb
+++ b/spec/controllers/taxonomies_controller_spec.rb
@@ -2,6 +2,11 @@ require "rails_helper"
 require "json"
 
 RSpec.describe TaxonomiesController, type: :controller do
+  let(:admin) { FactoryBot.create(:user, :admin) }
+  let(:analyst) { FactoryBot.create(:user, :analyst) }
+  let(:guest) { FactoryBot.create(:user) }
+  let(:manager) { FactoryBot.create(:user, :manager) }
+
   describe "Get index" do
     subject { get :index, format: :json }
     let!(:taxonomy) { FactoryBot.create(:taxonomy) }
@@ -29,8 +34,6 @@ RSpec.describe TaxonomiesController, type: :controller do
     end
 
     context "when signed in" do
-      let(:guest) { FactoryBot.create(:user) }
-      let(:user) { FactoryBot.create(:user, :manager) }
       let(:taxonomy) { FactoryBot.create(:taxonomy) }
 
       subject do
@@ -54,8 +57,18 @@ RSpec.describe TaxonomiesController, type: :controller do
         expect(subject).to be_forbidden
       end
 
+      it "will not allow an analyst to create a taxonomy" do
+        sign_in analyst
+        expect(subject).to be_forbidden
+      end
+
       it "will not allow a manager to create a taxonomy" do
-        sign_in user
+        sign_in manager
+        expect(subject).to be_forbidden
+      end
+
+      it "will not allow an admin to create a taxonomy" do
+        sign_in admin
         expect(subject).to be_forbidden
       end
     end
@@ -77,16 +90,23 @@ RSpec.describe TaxonomiesController, type: :controller do
     end
 
     context "when user signed in" do
-      let(:guest) { FactoryBot.create(:user) }
-      let(:user) { FactoryBot.create(:user, :manager) }
-
       it "will not allow a guest to update a taxonomy" do
         sign_in guest
         expect(subject).to be_forbidden
       end
 
+      it "will not allow an analyst to update a taxonomy" do
+        sign_in analyst
+        expect(subject).to be_forbidden
+      end
+
       it "will not allow a manager to update a taxonomy" do
-        sign_in user
+        sign_in manager
+        expect(subject).to be_forbidden
+      end
+
+      it "will not allow an admin to update a taxonomy" do
+        sign_in admin
         expect(subject).to be_forbidden
       end
     end
@@ -103,16 +123,23 @@ RSpec.describe TaxonomiesController, type: :controller do
     end
 
     context "when user signed in" do
-      let(:guest) { FactoryBot.create(:user) }
-      let(:user) { FactoryBot.create(:user, :manager) }
-
       it "will not allow a guest to delete a taxonomy" do
         sign_in guest
         expect(subject).to be_forbidden
       end
 
+      it "will not allow an analyst to delete a taxonomy" do
+        sign_in analyst
+        expect(subject).to be_forbidden
+      end
+
       it "will not allow a manager to delete a taxonomy" do
-        sign_in user
+        sign_in manager
+        expect(subject).to be_forbidden
+      end
+
+      it "will not allow an admin to delete a taxonomy" do
+        sign_in admin
         expect(subject).to be_forbidden
       end
     end

--- a/spec/models/taxonomy_spec.rb
+++ b/spec/models/taxonomy_spec.rb
@@ -28,7 +28,15 @@ RSpec.describe Taxonomy, type: :model do
       sub_taxonomy = FactoryBot.create(:taxonomy)
       taxonomy = FactoryBot.create(:taxonomy, :sub_taxonomy)
       sub_taxonomy.parent_id = taxonomy.id
-      expect { sub_taxonomy.save! }.to raise_exception(/Parent taxonomy is already a sub-taxonomy./)
+      expect(sub_taxonomy).to be_invalid
+      expect(sub_taxonomy.errors[:parent_id]).to include("Parent taxonomy is already a sub-taxonomy")
+    end
+
+    it "Can't be its own parent" do
+      taxonomy = FactoryBot.create(:taxonomy)
+      taxonomy.update(parent_id: taxonomy.id)
+      expect(taxonomy).to be_invalid
+      expect(taxonomy.errors[:parent_id]).to include("Taxonomy can't be its own parent")
     end
   end
 end


### PR DESCRIPTION
Fixes #32 by implementing the required changes:

- Updating specs to cover analyst & admin permissions
- Inherit from `SystemPolicy` because it's a configuration table
- Switch to `ApplicationRecord` because we don't want it versioned

##### Permissions by role

- public: none
- registered, no role: none
- analyst: R
- manager: R
- admin: R

##### Rules 

- a taxonomy can't be its own parent (`parent_id != id`)