### PR TITLE
Destroy `actor_categories` relationships when category is destroyed

### DIFF
--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -2,6 +2,7 @@ class Category < VersionedRecord
   belongs_to :taxonomy
   belongs_to :category, class_name: "Category", foreign_key: :parent_id, optional: true
   belongs_to :manager, class_name: "User", foreign_key: :manager_id, optional: true, inverse_of: :categories
+  has_many :actor_categories, inverse_of: :category, dependent: :destroy
   has_many :categories, foreign_key: :parent_id, class_name: "Category"
   has_many :recommendation_categories, inverse_of: :category, dependent: :destroy
   has_many :user_categories, inverse_of: :category, dependent: :destroy

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -63,7 +63,11 @@ RSpec.describe Category, type: :model do
     end
 
     it "is expected to cascade destroy dependent relationships" do
-      category = FactoryBot.create(:category, taxonomy: FactoryBot.create(:taxonomy, measuretypes: [FactoryBot.create(:measuretype)]))
+      actor = FactoryBot.create(:actor)
+      taxonomy = FactoryBot.create(:taxonomy, actortype_ids: [actor.actortype_id], measuretypes: [FactoryBot.create(:measuretype)])
+
+      category = FactoryBot.create(:category, taxonomy: taxonomy)
+      FactoryBot.create(:actor_category, actor: actor, category: category)
       FactoryBot.create(:user_category, category: category)
       FactoryBot.create(:recommendation_category, category: category)
 
@@ -74,11 +78,12 @@ RSpec.describe Category, type: :model do
       expect { category.destroy }.to change {
         [
           Category.count,
+          ActorCategory.count,
           UserCategory.count,
           RecommendationCategory.count,
           MeasureCategory.count
         ]
-      }.from([1, 1, 1, 1]).to([0, 0, 0, 0])
+      }.from([1, 1, 1, 1, 1]).to([0, 0, 0, 0, 0])
     end
   end
 end


### PR DESCRIPTION
Fixes #76 by destroying all `actor_categories` for a `category`
when that `category` is destroyed.