### PR TITLE
Specify `user_roles` permissions

### DIFF
--- a/app/policies/user_role_policy.rb
+++ b/app/policies/user_role_policy.rb
@@ -1,38 +1,31 @@
 # frozen_string_literal: true
 
 class UserRolePolicy < ApplicationPolicy
-  def index?
-    true
-  end
-
-  def show?
-    @user.role?("admin") || @user.role?("manager")
-  end
-
   def update?
     false
   end
 
   def create?
-    return true if @user.role?("admin")
-    @user.role?("manager") && %w[manager admin].exclude?(@record.role_name) && !(@record.user.role?("admin") || @record.user.role?("manager"))
+    @user.role?("admin")
   end
 
   def destroy?
-    return true if @user.role?("admin")
-    @user.role?("manager") && %w[manager admin].exclude?(@record.role_name) && !(@record.user.role?("admin") || @record.user.role?("manager"))
+    @user.role?("admin")
   end
 
   def permitted_attributes
-    [:user_id,
+    [
+      :user_id,
       :role_id,
       user_attributes: [:id],
-      role_attributes: [:id]]
+      role_attributes: [:id]
+    ]
   end
 
   class Scope < Scope
     def resolve
-      return scope.all if @user.role?("admin") || @user.role?("manager")
+      return super if @user.role?("admin") || @user.role?("manager") || @user.role?("analyst")
+
       scope.where(user_id: @user.id)
     end
   end


### PR DESCRIPTION
Fixes #36 by implementing required permissions:

##### Permissions by role

- public: none
- registered, no role: none
- analyst: R
- manager: R
- admin: CRD