### PR TITLE
Make sure that only owner can CRUD bookmarks

### DIFF
--- a/app/controllers/bookmarks_controller.rb
+++ b/app/controllers/bookmarks_controller.rb
@@ -1,7 +1,7 @@
 class BookmarksController < ApplicationController
   before_action :authenticate_user!
   before_action :set_and_authorize_bookmark, only: [:update, :destroy]
-  skip_before_action :authorize_base_object!, only: [:show]
+  skip_before_action :authorize_base_object!
   skip_after_action :verify_authorized, only: [:show]
 
   def forbidden

--- a/app/policies/bookmark_policy.rb
+++ b/app/policies/bookmark_policy.rb
@@ -1,18 +1,18 @@
 class BookmarkPolicy < ApplicationPolicy
   def create?
-    index?
+    @record.user == @user
   end
 
   def edit?
-    true
+    @record.user == @user
   end
 
   def update?
-    true
+    @record.user == @user
   end
 
   def destroy?
-    true
+    @record.user == @user
   end
 
   def permitted_attributes
@@ -21,7 +21,7 @@ class BookmarkPolicy < ApplicationPolicy
 
   class Scope < Scope
     def resolve
-      scope.all
+      scope.where(user_id: @user.id)
     end
   end
 end

--- a/spec/controllers/bookmarks_controller_spec.rb
+++ b/spec/controllers/bookmarks_controller_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe BookmarksController, type: :controller do
     subject { get :index, format: :json }
 
     context "when not signed in" do
-      it { expect(subject).to be_forbidden }
+      it { expect(subject).to be_unauthorized }
     end
 
     context "when signed in" do
@@ -122,7 +122,7 @@ RSpec.describe BookmarksController, type: :controller do
           id: bookmark2.id, bookmark: {title: new_title, view: new_view}
         }
 
-        expect(subject).to have_http_status(403)
+        expect(subject).to have_http_status(404)
       end
     end
   end
@@ -152,7 +152,7 @@ RSpec.describe BookmarksController, type: :controller do
 
         subject = delete :destroy, format: :json, params: {id: bookmark2.id}
 
-        expect(subject).to have_http_status(403)
+        expect(subject).to have_http_status(404)
       end
     end
   end


### PR DESCRIPTION
Fixes #37 by specifying that only the owner of a bookmark can
create, read, update, or destroy it.