### PR TITLE
Add `resourcetypes` API

### DIFF
--- a/app/controllers/resourcetypes_controller.rb
+++ b/app/controllers/resourcetypes_controller.rb
@@ -1,0 +1,31 @@
+class ResourcetypesController < ApplicationController
+  before_action :set_and_authorize_resourcetype, only: [:show]
+
+  # GET /resourcetypes
+  def index
+    @resourcetypes = policy_scope(base_object).order(created_at: :desc).page(params[:page])
+    authorize @resourcetypes
+
+    render json: serialize(@resourcetypes)
+  end
+
+  # GET /resourcetypes/1
+  def show
+    render json: serialize(@resourcetype)
+  end
+
+  private
+
+  def set_and_authorize_resourcetype
+    @resourcetype = policy_scope(base_object).find(params[:id])
+    authorize @resourcetype
+  end
+
+  def base_object
+    Resourcetype
+  end
+
+  def serialize(target, serializer: ResourcetypeSerializer)
+    super
+  end
+end

--- a/app/models/resourcetype.rb
+++ b/app/models/resourcetype.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Resourcetype < ApplicationRecord
+  has_many :resources
+
+  validates :title, presence: true
+end

--- a/app/policies/resourcetype_policy.rb
+++ b/app/policies/resourcetype_policy.rb
@@ -1,0 +1,4 @@
+# frozen_string_literal: true
+
+class ResourcetypePolicy < SystemPolicy
+end

--- a/app/serializers/resourcetype_serializer.rb
+++ b/app/serializers/resourcetype_serializer.rb
@@ -1,0 +1,7 @@
+class ResourcetypeSerializer
+  include FastApplicationSerializer
+
+  attributes :title
+
+  set_type :resourcetypes
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Rails.application.routes.draw do
   resources :measuretypes, only: [:index, :show]
   resources :memberships, only: [:index, :show, :create, :destroy]
   resources :recommendation_categories
+  resources :resourcetypes, only: [:index, :show]
   resources :user_categories
   resources :recommendation_measures
   resources :categories do

--- a/db/migrate/20211117081925_create_resourcetypes.rb
+++ b/db/migrate/20211117081925_create_resourcetypes.rb
@@ -1,0 +1,9 @@
+class CreateResourcetypes < ActiveRecord::Migration[6.1]
+  def change
+    create_table :resourcetypes do |t|
+      t.string :title, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_16_065947) do
+ActiveRecord::Schema.define(version: 2021_11_17_081925) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -349,6 +349,12 @@ ActiveRecord::Schema.define(version: 2021_11_16_065947) do
     t.integer "created_by_id"
     t.index ["draft"], name: "index_recommendations_on_draft"
     t.index ["framework_id"], name: "index_recommendations_on_framework_id"
+  end
+
+  create_table "resourcetypes", force: :cascade do |t|
+    t.string "title", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
   end
 
   create_table "roles", id: :serial, force: :cascade do |t|

--- a/spec/controllers/resourcetypes_controller_spec.rb
+++ b/spec/controllers/resourcetypes_controller_spec.rb
@@ -1,0 +1,61 @@
+require "rails_helper"
+require "json"
+
+RSpec.describe ResourcetypesController, type: :controller do
+  describe "Get index" do
+    subject { get :index, format: :json }
+
+    context "when not signed in" do
+      it { expect(subject).to be_forbidden }
+    end
+
+    context "when signed in" do
+      context "as analyst" do
+        before { sign_in FactoryBot.create(:user, :analyst) }
+
+        it { expect(subject).to be_ok }
+      end
+
+      context "as manager" do
+        before { sign_in FactoryBot.create(:user, :manager) }
+
+        it { expect(subject).to be_ok }
+      end
+
+      context "as admin" do
+        before { sign_in FactoryBot.create(:user, :admin) }
+
+        it { expect(subject).to be_ok }
+      end
+    end
+  end
+
+  describe "Get show" do
+    let(:resourcetype) { FactoryBot.create(:resourcetype) }
+    subject { get :show, params: {id: resourcetype}, format: :json }
+
+    context "when not signed in" do
+      it { expect(subject).to be_forbidden }
+    end
+
+    context "when signed in" do
+      context "as analyst" do
+        before { sign_in FactoryBot.create(:user, :analyst) }
+
+        it { expect(subject).to be_ok }
+      end
+
+      context "as manager" do
+        before { sign_in FactoryBot.create(:user, :manager) }
+
+        it { expect(subject).to be_ok }
+      end
+
+      context "as admin" do
+        before { sign_in FactoryBot.create(:user, :admin) }
+
+        it { expect(subject).to be_ok }
+      end
+    end
+  end
+end

--- a/spec/factories/resourcetypes.rb
+++ b/spec/factories/resourcetypes.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :resourcetype do
+    title { Faker::Creature::Cat.registry }
+  end
+end

--- a/spec/models/resourcetype_spec.rb
+++ b/spec/models/resourcetype_spec.rb
@@ -1,0 +1,6 @@
+require "rails_helper"
+
+RSpec.describe Resourcetype, type: :model do
+  it { is_expected.to validate_presence_of :title }
+  # it { is_expected.to have_many :resources }
+end


### PR DESCRIPTION
Fixes #29

We want a system config table called `resourcetypes`.
This works exactly the same as `measuretypes`, but with a different
name.

- configuration table for the different types of resources
- e.g. documents, websites

##### Permissions by role

- public: none
- registered, no role: none
- analyst: R
- manager: R
- admin: R