### PR TITLE
Create `measure_resources` table and API

### DIFF
--- a/app/controllers/measure_resources_controller.rb
+++ b/app/controllers/measure_resources_controller.rb
@@ -1,0 +1,50 @@
+class MeasureResourcesController < ApplicationController
+  before_action :set_and_authorize_measure_resource, only: [:show, :destroy]
+
+  # GET /measure_resources
+  def index
+    @measure_resources = policy_scope(base_object).order(created_at: :desc).page(params[:page])
+    authorize @measure_resources
+
+    render json: serialize(@measure_resources)
+  end
+
+  # GET /measure_resources/1
+  def show
+    render json: serialize(@measure_resource)
+  end
+
+  # POST /measure_resources
+  def create
+    @measure_resource = MeasureResource.new
+    @measure_resource.assign_attributes(permitted_attributes(@measure_resource))
+    authorize @measure_resource
+
+    if @measure_resource.save
+      render json: serialize(@measure_resource), status: :created, location: @measure_resource
+    else
+      render json: @measure_resource.errors, status: :unprocessable_entity
+    end
+  end
+
+  # DELETE /measure_resources/1
+  def destroy
+    @measure_resource.destroy
+  end
+
+  private
+
+  # Use callbacks to share common setup or constraints between actions.
+  def set_and_authorize_measure_resource
+    @measure_resource = policy_scope(base_object).find(params[:id])
+    authorize @measure_resource
+  end
+
+  def base_object
+    MeasureResource
+  end
+
+  def serialize(target, serializer: MeasureResourceSerializer)
+    super
+  end
+end

--- a/app/models/measure_resource.rb
+++ b/app/models/measure_resource.rb
@@ -1,0 +1,10 @@
+class MeasureResource < ApplicationRecord
+  belongs_to :measure, required: true
+  belongs_to :resource, required: true
+
+  accepts_nested_attributes_for :measure
+  accepts_nested_attributes_for :resource
+
+  validates :measure_id, presence: true
+  validates :resource_id, presence: true, uniqueness: {scope: :measure_id}
+end

--- a/app/policies/measure_resource_policy.rb
+++ b/app/policies/measure_resource_policy.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class MeasureResourcePolicy < ApplicationPolicy
+  def permitted_attributes
+    [
+      :measure_id,
+      :resource_id
+    ]
+  end
+
+  def update?
+    false
+  end
+end

--- a/app/serializers/measure_resource_serializer.rb
+++ b/app/serializers/measure_resource_serializer.rb
@@ -1,0 +1,7 @@
+class MeasureResourceSerializer
+  include FastApplicationSerializer
+
+  attributes :measure_id, :resource_id
+
+  set_type :measure_resources
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   resources :measure_actors, only: [:index, :show, :create, :update, :destroy]
   resources :measure_categories
   resources :measure_indicators
+  resources :measure_resources
   resources :measuretype_taxonomies, only: [:index, :show]
   resources :measuretypes, only: [:index, :show]
   resources :memberships, only: [:index, :show, :create, :destroy]

--- a/db/migrate/20211124072059_create_measure_resources.rb
+++ b/db/migrate/20211124072059_create_measure_resources.rb
@@ -1,0 +1,11 @@
+class CreateMeasureResources < ActiveRecord::Migration[6.1]
+  def change
+    create_table :measure_resources do |t|
+      t.belongs_to :measure, null: false, foreign_key: true
+      t.belongs_to :resource, null: false, foreign_key: true
+
+      t.belongs_to :created_by, index: true, foreign_key: {to_table: "users"}
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_17_084146) do
+ActiveRecord::Schema.define(version: 2021_11_24_072059) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -206,6 +206,17 @@ ActiveRecord::Schema.define(version: 2021_11_17_084146) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "created_by_id"
+  end
+
+  create_table "measure_resources", force: :cascade do |t|
+    t.bigint "measure_id", null: false
+    t.bigint "resource_id", null: false
+    t.bigint "created_by_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["created_by_id"], name: "index_measure_resources_on_created_by_id"
+    t.index ["measure_id"], name: "index_measure_resources_on_measure_id"
+    t.index ["resource_id"], name: "index_measure_resources_on_resource_id"
   end
 
   create_table "measures", id: :serial, force: :cascade do |t|
@@ -478,6 +489,9 @@ ActiveRecord::Schema.define(version: 2021_11_17_084146) do
   add_foreign_key "measure_actors", "measures"
   add_foreign_key "measure_actors", "users", column: "created_by_id"
   add_foreign_key "measure_actors", "users", column: "updated_by_id"
+  add_foreign_key "measure_resources", "measures"
+  add_foreign_key "measure_resources", "resources"
+  add_foreign_key "measure_resources", "users", column: "created_by_id"
   add_foreign_key "measures", "measures", column: "parent_id"
   add_foreign_key "measures", "measuretypes"
   add_foreign_key "measuretype_taxonomies", "measuretypes"

--- a/spec/controllers/measure_resources_controller_spec.rb
+++ b/spec/controllers/measure_resources_controller_spec.rb
@@ -1,0 +1,91 @@
+require "rails_helper"
+require "json"
+
+RSpec.describe MeasureResourcesController, type: :controller do
+  let(:measure) { FactoryBot.create(:measure) }
+  let(:resource) { FactoryBot.create(:resource) }
+
+  describe "Get index" do
+    subject { get :index, format: :json }
+
+    context "when not signed in" do
+      it { expect(subject).to be_forbidden }
+    end
+  end
+
+  describe "Get show" do
+    let(:measure_resource) { FactoryBot.create(:measure_resource, resource: resource, measure: measure) }
+    subject { get :show, params: {id: measure_resource}, format: :json }
+
+    context "when not signed in" do
+      it { expect(subject).to be_forbidden }
+    end
+  end
+
+  describe "Post create" do
+    context "when not signed in" do
+      it "not allow creating a measure_resource" do
+        post :create, format: :json, params: {measure_resource: {measure_id: 1, resource_id: 1}}
+        expect(response).to be_unauthorized
+      end
+    end
+
+    context "when signed in" do
+      let(:guest) { FactoryBot.create(:user) }
+      let(:user) { FactoryBot.create(:user, :manager) }
+
+      subject do
+        post :create,
+          format: :json,
+          params: {
+            measure_resource: {
+              measure_id: measure.id,
+              resource_id: resource.id
+            }
+          }
+      end
+
+      it "will not allow a guest to create a measure_resource" do
+        sign_in guest
+        expect(subject).to be_forbidden
+      end
+
+      it "will allow a manager to create a measure_resource" do
+        sign_in user
+        expect(subject).to be_created
+      end
+
+      it "will return an error if params are incorrect" do
+        sign_in user
+        post :create, format: :json, params: {measure_resource: {description: "desc only", taxonomy_id: 999}}
+        expect(response).to have_http_status(422)
+      end
+    end
+  end
+
+  describe "Delete destroy" do
+    let(:measure_resource) { FactoryBot.create(:measure_resource, resource: resource, measure: measure) }
+    subject { delete :destroy, format: :json, params: {id: measure_resource} }
+
+    context "when not signed in" do
+      it "not allow deleting a measure_resource" do
+        expect(subject).to be_unauthorized
+      end
+    end
+
+    context "when user signed in" do
+      let(:guest) { FactoryBot.create(:user) }
+      let(:user) { FactoryBot.create(:user, :manager) }
+
+      it "will not allow a guest to delete a measure_resource" do
+        sign_in guest
+        expect(subject).to be_forbidden
+      end
+
+      it "will allow a manager to delete a measure_resource" do
+        sign_in user
+        expect(subject).to be_no_content
+      end
+    end
+  end
+end

--- a/spec/controllers/roles_controller_spec.rb
+++ b/spec/controllers/roles_controller_spec.rb
@@ -88,7 +88,7 @@ RSpec.describe RolesController, type: :controller do
     end
 
     context "when not signed in" do
-      it "not allow updating a measure" do
+      it "not allow updating a role" do
         expect(subject).to be_unauthorized
       end
     end
@@ -98,7 +98,7 @@ RSpec.describe RolesController, type: :controller do
       let(:manager) { FactoryBot.create(:user, :manager) }
       let(:admin) { FactoryBot.create(:user, :admin) }
 
-      it "will not allow a guest to update a measure" do
+      it "will not allow a guest to update a role" do
         sign_in guest
         expect(subject).to be_forbidden
       end
@@ -120,7 +120,7 @@ RSpec.describe RolesController, type: :controller do
     subject { delete :destroy, format: :json, params: {id: role} }
 
     context "when not signed in" do
-      it "not allow deleting a measure" do
+      it "not allow deleting a role" do
         expect(subject).to be_unauthorized
       end
     end

--- a/spec/factories/measure_resources.rb
+++ b/spec/factories/measure_resources.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :measure_resource do
+    association :measure
+    association :resource
+
+    association :created_by, factory: :user
+  end
+end

--- a/spec/models/measure_resource_spec.rb
+++ b/spec/models/measure_resource_spec.rb
@@ -1,0 +1,8 @@
+require "rails_helper"
+
+RSpec.describe MeasureResource, type: :model do
+  it { is_expected.to belong_to :measure }
+  it { is_expected.to belong_to :resource }
+  it { is_expected.to validate_presence_of :resource_id }
+  it { is_expected.to validate_presence_of :measure_id }
+end


### PR DESCRIPTION
Note: this is based on #86 until it's merged

Fixes #30 

- simple many-to-many "join" table linking activities with resources

##### Permissions by role

- public: none
- registered, no role: none
- analyst: R
- manager: CRD
- admin: CRD