### PR TITLE
Add versioning fields to editable join tables

### DIFF
--- a/app/models/actor_category.rb
+++ b/app/models/actor_category.rb
@@ -1,4 +1,4 @@
-class ActorCategory < ApplicationRecord
+class ActorCategory < VersionedRecord
   belongs_to :actor, required: true
   belongs_to :category, required: true
 

--- a/app/models/measure_category.rb
+++ b/app/models/measure_category.rb
@@ -1,4 +1,4 @@
-class MeasureCategory < ApplicationRecord
+class MeasureCategory < VersionedRecord
   belongs_to :measure
   belongs_to :category
   accepts_nested_attributes_for :measure

--- a/app/models/measure_resource.rb
+++ b/app/models/measure_resource.rb
@@ -1,4 +1,4 @@
-class MeasureResource < ApplicationRecord
+class MeasureResource < VersionedRecord
   belongs_to :measure, required: true
   belongs_to :resource, required: true
 

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -1,4 +1,4 @@
-class Membership < ApplicationRecord
+class Membership < VersionedRecord
   belongs_to :member, class_name: "Actor", required: true
   belongs_to :memberof, class_name: "Actor", required: true
 

--- a/app/serializers/actor_category_serializer.rb
+++ b/app/serializers/actor_category_serializer.rb
@@ -1,5 +1,5 @@
 class ActorCategorySerializer
-  include FastApplicationSerializer
+  include FastVersionedSerializer
 
   attributes :actor_id, :category_id
 

--- a/app/serializers/measure_category_serializer.rb
+++ b/app/serializers/measure_category_serializer.rb
@@ -1,5 +1,5 @@
 class MeasureCategorySerializer
-  include FastApplicationSerializer
+  include FastVersionedSerializer
 
   attributes :measure_id, :category_id
 

--- a/app/serializers/measure_resource_serializer.rb
+++ b/app/serializers/measure_resource_serializer.rb
@@ -1,5 +1,5 @@
 class MeasureResourceSerializer
-  include FastApplicationSerializer
+  include FastVersionedSerializer
 
   attributes :measure_id, :resource_id
 

--- a/app/serializers/membership_serializer.rb
+++ b/app/serializers/membership_serializer.rb
@@ -1,5 +1,5 @@
 class MembershipSerializer
-  include FastApplicationSerializer
+  include FastVersionedSerializer
 
   attributes :member_id, :memberof_id, :created_by_id
 

--- a/app/serializers/user_role_serializer.rb
+++ b/app/serializers/user_role_serializer.rb
@@ -1,5 +1,5 @@
 class UserRoleSerializer
-  include FastApplicationSerializer
+  include FastVersionedSerializer
 
   attributes :user_id, :role_id
 

--- a/db/migrate/20220123224010_add_versioned_fields_to_joins.rb
+++ b/db/migrate/20220123224010_add_versioned_fields_to_joins.rb
@@ -1,0 +1,19 @@
+class AddVersionedFieldsToJoins < ActiveRecord::Migration[6.1]
+  def change
+    change_table(:actor_categories) do |t|
+      t.belongs_to :updated_by, foreign_key: {to_table: "users"}, index: true, null: true
+    end
+
+    change_table(:measure_categories) do |t|
+      t.belongs_to :updated_by, foreign_key: {to_table: "users"}, index: true, null: true
+    end
+
+    change_table(:memberships) do |t|
+      t.belongs_to :updated_by, foreign_key: {to_table: "users"}, index: true, null: true
+    end
+
+    change_table(:measure_resources) do |t|
+      t.belongs_to :updated_by, foreign_key: {to_table: "users"}, index: true, null: true
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_11_24_072059) do
+ActiveRecord::Schema.define(version: 2022_01_23_224010) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,9 +21,11 @@ ActiveRecord::Schema.define(version: 2021_11_24_072059) do
     t.bigint "created_by_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "updated_by_id"
     t.index ["actor_id"], name: "index_actor_categories_on_actor_id"
     t.index ["category_id"], name: "index_actor_categories_on_category_id"
     t.index ["created_by_id"], name: "index_actor_categories_on_created_by_id"
+    t.index ["updated_by_id"], name: "index_actor_categories_on_updated_by_id"
   end
 
   create_table "actor_measures", force: :cascade do |t|
@@ -198,6 +200,8 @@ ActiveRecord::Schema.define(version: 2021_11_24_072059) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "created_by_id"
+    t.bigint "updated_by_id"
+    t.index ["updated_by_id"], name: "index_measure_categories_on_updated_by_id"
   end
 
   create_table "measure_indicators", id: :serial, force: :cascade do |t|
@@ -214,9 +218,11 @@ ActiveRecord::Schema.define(version: 2021_11_24_072059) do
     t.bigint "created_by_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "updated_by_id"
     t.index ["created_by_id"], name: "index_measure_resources_on_created_by_id"
     t.index ["measure_id"], name: "index_measure_resources_on_measure_id"
     t.index ["resource_id"], name: "index_measure_resources_on_resource_id"
+    t.index ["updated_by_id"], name: "index_measure_resources_on_updated_by_id"
   end
 
   create_table "measures", id: :serial, force: :cascade do |t|
@@ -276,9 +282,11 @@ ActiveRecord::Schema.define(version: 2021_11_24_072059) do
     t.bigint "created_by_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.bigint "updated_by_id"
     t.index ["created_by_id"], name: "index_memberships_on_created_by_id"
     t.index ["member_id"], name: "index_memberships_on_member_id"
     t.index ["memberof_id"], name: "index_memberships_on_memberof_id"
+    t.index ["updated_by_id"], name: "index_memberships_on_updated_by_id"
   end
 
   create_table "pages", id: :serial, force: :cascade do |t|
@@ -473,9 +481,10 @@ ActiveRecord::Schema.define(version: 2021_11_24_072059) do
   add_foreign_key "actor_categories", "actors"
   add_foreign_key "actor_categories", "categories"
   add_foreign_key "actor_categories", "users", column: "created_by_id"
+  add_foreign_key "actor_categories", "users", column: "updated_by_id"
   add_foreign_key "actor_measures", "actors"
   add_foreign_key "actor_measures", "measures"
-  add_foreign_key "actor_measures", "resources", column: "resource_id"
+  add_foreign_key "actor_measures", "resources"
   add_foreign_key "actor_measures", "users", column: "created_by_id"
   add_foreign_key "actor_measures", "users", column: "updated_by_id"
   add_foreign_key "actors", "actortypes"
@@ -489,9 +498,11 @@ ActiveRecord::Schema.define(version: 2021_11_24_072059) do
   add_foreign_key "measure_actors", "measures"
   add_foreign_key "measure_actors", "users", column: "created_by_id"
   add_foreign_key "measure_actors", "users", column: "updated_by_id"
+  add_foreign_key "measure_categories", "users", column: "updated_by_id"
   add_foreign_key "measure_resources", "measures"
   add_foreign_key "measure_resources", "resources"
   add_foreign_key "measure_resources", "users", column: "created_by_id"
+  add_foreign_key "measure_resources", "users", column: "updated_by_id"
   add_foreign_key "measures", "measures", column: "parent_id"
   add_foreign_key "measures", "measuretypes"
   add_foreign_key "measuretype_taxonomies", "measuretypes"
@@ -499,6 +510,7 @@ ActiveRecord::Schema.define(version: 2021_11_24_072059) do
   add_foreign_key "memberships", "actors", column: "member_id"
   add_foreign_key "memberships", "actors", column: "memberof_id"
   add_foreign_key "memberships", "users", column: "created_by_id"
+  add_foreign_key "memberships", "users", column: "updated_by_id"
   add_foreign_key "recommendation_indicators", "indicators"
   add_foreign_key "recommendation_indicators", "recommendations"
   add_foreign_key "recommendation_recommendations", "recommendations"

--- a/spec/controllers/actor_categories_controller_spec.rb
+++ b/spec/controllers/actor_categories_controller_spec.rb
@@ -63,6 +63,13 @@ RSpec.describe ActorCategoriesController, type: :controller do
         post :create, format: :json, params: {actor_category: {description: "desc only", taxonomy_id: 999}}
         expect(response).to have_http_status(422)
       end
+
+      it "will record what manager created the actor category", versioning: true do
+        expect(PaperTrail).to be_enabled
+        sign_in user
+        json = JSON.parse(subject.body)
+        expect(json.dig("data", "attributes", "updated_by_id").to_i).to eq user.id
+      end
     end
   end
 

--- a/spec/controllers/measure_categories_controller_spec.rb
+++ b/spec/controllers/measure_categories_controller_spec.rb
@@ -63,6 +63,13 @@ RSpec.describe MeasureCategoriesController, type: :controller do
         post :create, format: :json, params: {measure_category: {description: "desc only", taxonomy_id: 999}}
         expect(response).to have_http_status(422)
       end
+
+      it "will record what manager created the measure category", versioning: true do
+        expect(PaperTrail).to be_enabled
+        sign_in user
+        json = JSON.parse(subject.body)
+        expect(json.dig("data", "attributes", "updated_by_id").to_i).to eq user.id
+      end
     end
   end
 

--- a/spec/controllers/measure_resources_controller_spec.rb
+++ b/spec/controllers/measure_resources_controller_spec.rb
@@ -60,6 +60,13 @@ RSpec.describe MeasureResourcesController, type: :controller do
         post :create, format: :json, params: {measure_resource: {description: "desc only", taxonomy_id: 999}}
         expect(response).to have_http_status(422)
       end
+
+      it "will record what manager created the measure resource", versioning: true do
+        expect(PaperTrail).to be_enabled
+        sign_in user
+        json = JSON.parse(subject.body)
+        expect(json.dig("data", "attributes", "updated_by_id").to_i).to eq user.id
+      end
     end
   end
 

--- a/spec/controllers/memberships_controller_spec.rb
+++ b/spec/controllers/memberships_controller_spec.rb
@@ -65,6 +65,13 @@ RSpec.describe MembershipsController, type: :controller do
         post :create, format: :json, params: {membership: {description: "desc only", taxonomy_id: 999}}
         expect(response).to have_http_status(422)
       end
+
+      it "will record what manager created the membership", versioning: true do
+        expect(PaperTrail).to be_enabled
+        sign_in manager
+        json = JSON.parse(subject.body)
+        expect(json.dig("data", "attributes", "updated_by_id").to_i).to eq manager.id
+      end
     end
   end
 

--- a/spec/controllers/user_roles_controller_spec.rb
+++ b/spec/controllers/user_roles_controller_spec.rb
@@ -189,6 +189,21 @@ RSpec.describe UserRolesController, type: :controller do
         post :create, format: :json, params: {user_role: {description: "desc only", taxonomy_id: 999}}
         expect(response).to have_http_status(422)
       end
+
+      it "will record what admin created the user role", versioning: true do
+        expect(PaperTrail).to be_enabled
+        sign_in admin
+        subject = post :create,
+          format: :json,
+          params: {
+            user_role: {
+              user_id: manager.id,
+              role_id: admin_role.id
+            }
+          }
+        json = JSON.parse(subject.body)
+        expect(json.dig("data", "attributes", "updated_by_id").to_i).to eq admin.id
+      end
     end
   end
 


### PR DESCRIPTION
Fixes #92 

We want to have `updated_by` information for "editable" join tables.

This adds the required `updated_by_id` foreign key to the tables and
updates the serializers to return it.