### PR TITLE
Add `relationshiptype_id` to `actor_measures`

### DIFF
--- a/app/policies/actor_measure_policy.rb
+++ b/app/policies/actor_measure_policy.rb
@@ -8,6 +8,7 @@ class ActorMeasurePolicy < ApplicationPolicy
       :date_end,
       :date_start,
       :measure_id,
+      :relationshiptype_id,
       :updated_by_id,
       :value
     ]

--- a/app/serializers/actor_measure_serializer.rb
+++ b/app/serializers/actor_measure_serializer.rb
@@ -7,8 +7,9 @@ class ActorMeasureSerializer
     :date_end,
     :date_start,
     :measure_id,
+    :relationshiptype_id,
     :updated_by_id,
-    :value
+    :value,
   )
 
   set_type :actor_measures

--- a/app/serializers/actor_measure_serializer.rb
+++ b/app/serializers/actor_measure_serializer.rb
@@ -9,7 +9,7 @@ class ActorMeasureSerializer
     :measure_id,
     :relationshiptype_id,
     :updated_by_id,
-    :value,
+    :value
   )
 
   set_type :actor_measures

--- a/db/migrate/20220601085513_add_relationshiptype_id_to_actor_measures.rb
+++ b/db/migrate/20220601085513_add_relationshiptype_id_to_actor_measures.rb
@@ -1,0 +1,5 @@
+class AddRelationshiptypeIdToActorMeasures < ActiveRecord::Migration[6.1]
+  def change
+    add_column :actor_measures, :relationshiptype_id, :bigint
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_23_224010) do
+ActiveRecord::Schema.define(version: 2022_06_01_085513) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2022_01_23_224010) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.bigint "resource_id"
+    t.bigint "relationshiptype_id"
     t.index ["actor_id"], name: "index_actor_measures_on_actor_id"
     t.index ["created_by_id"], name: "index_actor_measures_on_created_by_id"
     t.index ["measure_id"], name: "index_actor_measures_on_measure_id"

--- a/spec/controllers/actors_measures_controller_spec.rb
+++ b/spec/controllers/actors_measures_controller_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe ActorMeasuresController, type: :controller do
       put :update,
         format: :json,
         params: {id: actor_measure,
-                 actor_measure: {value: "4.2"}}
+                 actor_measure: {value: "4.2", relationshiptype_id: 1}}
     end
 
     context "when not signed in" do
@@ -94,6 +94,7 @@ RSpec.describe ActorMeasuresController, type: :controller do
         expect(subject).to be_ok
         json = JSON.parse(subject.body)
         expect(json.dig("data", "attributes", "value")).to eq("4.2")
+        expect(json.dig("data", "attributes", "relationshiptype_id")).to eq(1)
       end
 
       it "will return an error if params are incorrect" do

--- a/spec/requests/actors_measures_spec.rb
+++ b/spec/requests/actors_measures_spec.rb
@@ -32,6 +32,7 @@ RSpec.describe "actor to measure relationships", type: :request do
               "date_end" => "2021-11-02",
               "date_start" => "2021-11-02",
               "measure_id" => actor_measure.measure_id,
+              "relationshiptype_id" => actor_measure.relationshiptype_id,
               "updated_at" => actor_measure.updated_at.in_time_zone.iso8601,
               "updated_by_id" => user.id,
               "value" => "3.14"
@@ -69,6 +70,7 @@ RSpec.describe "actor to measure relationships", type: :request do
                 "date_end" => "2021-11-02",
                 "date_start" => "2021-11-02",
                 "measure_id" => actor_measure_1.measure_id,
+                "relationshiptype_id" => actor_measure_1.relationshiptype_id,
                 "updated_at" => actor_measure_1.updated_at.in_time_zone.iso8601,
                 "updated_by_id" => user.id,
                 "value" => "3.14"
@@ -83,6 +85,7 @@ RSpec.describe "actor to measure relationships", type: :request do
                 "date_end" => "2021-11-02",
                 "date_start" => "2021-11-02",
                 "measure_id" => actor_measure_2.measure_id,
+                "relationshiptype_id" => actor_measure_2.relationshiptype_id,
                 "updated_at" => actor_measure_2.updated_at.in_time_zone.iso8601,
                 "updated_by_id" => user.id,
                 "value" => "3.14"
@@ -97,6 +100,7 @@ RSpec.describe "actor to measure relationships", type: :request do
                 "date_end" => "2021-11-02",
                 "date_start" => "2021-11-02",
                 "measure_id" => actor_measure_3.measure_id,
+                "relationshiptype_id" => actor_measure_3.relationshiptype_id,
                 "updated_at" => actor_measure_3.updated_at.in_time_zone.iso8601,
                 "updated_by_id" => user.id,
                 "value" => "3.14"


### PR DESCRIPTION
We want to be able to store the relationship type against
`actor_measures`.

For now this just means adding a column in the database and serving it
through the API, allowing it to be updated.

Fixes #95